### PR TITLE
Fix HTML titles for every page

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -12,11 +12,6 @@ import profilePicture from "@/public/static/profile.png";
 import "@/styles/mdx.css";
 import { Metadata } from "next";
 
-export const metadata: Metadata = {
-  title: "Post",
-  description: "Topic I've written about",
-};
-
 interface PostPageProps {
   params: {
     slug: string;
@@ -33,6 +28,21 @@ export async function generateStaticParams(): Promise<
   PostPageProps["params"][]
 > {
   return posts.map((post) => ({ slug: post.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: PostPageProps): Promise<Metadata> {
+  const post = await getPostFromParams(params);
+
+  if (!post || !post.published) {
+    return {};
+  }
+
+  return {
+    title: post.title,
+    description: post.description,
+  };
 }
 
 export default async function PostPage({ params }: PostPageProps) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,17 @@
 import ThemeContextProvider from "@/context";
 import { BodyLayout } from "./body-layout";
+import { siteConfig } from "@/lib/utils";
+import { Metadata } from "next";
 
 import "./globals.css";
+
+export const metadata: Metadata = {
+  title: {
+    default: siteConfig.name,
+    template: `%s | ${siteConfig.name}`,
+  },
+  description: siteConfig.description,
+};
 
 export default function RootLayout({
   children,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,12 +2,18 @@ import { posts } from "#site/content";
 import { PostItem } from "@/components/post-item";
 import { Tag } from "@/components/tag";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { getAllTags, sortPosts, sortTagsByCount } from "@/lib/utils";
+import { getAllTags, siteConfig, sortPosts, sortTagsByCount } from "@/lib/utils";
 import { Metadata } from "next";
 
-const metadata: Metadata = {
-  title: "My blog",
-  description: "Stunning things I've learned and want to share",
+// Note: app/page.tsx shares its route segment with the root app/layout.tsx,
+// so the layout's `title.template` does not apply here (Next.js only applies
+// a segment's template to its *child* segments). We build the full title
+// explicitly instead.
+export const metadata: Metadata = {
+  title: {
+    absolute: `Home | ${siteConfig.name}`,
+  },
+  description: siteConfig.description,
 };
 
 export default function BlogPage() {
@@ -20,9 +26,9 @@ export default function BlogPage() {
     <div className="py-6 xl:py-10">
       <div className="flex flex-col items-start gap-4 md:flex-row md:justify-between md:gap-8">
         <div className="flex-1 space-y-4">
-          <h1 className="inline-block font-black text-4xl lg:text-5xl">{`${metadata.title}`}</h1>
+          <h1 className="inline-block font-black text-4xl lg:text-5xl">{siteConfig.name}</h1>
           <p className="text-xl text-muted-foreground">
-            {metadata.description}
+            {siteConfig.description}
           </p>
         </div>
       </div>

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -4,6 +4,7 @@ import { Tag } from "@/components/tag";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getAllTags, getPostsByTagSlug, sortTagsByCount } from "@/lib/utils";
 import { slug } from "github-slugger";
+import { Metadata } from "next";
 
 interface TagPageProps {
   params: {
@@ -16,6 +17,15 @@ export const generateStaticParams = () => {
   const paths = Object.keys(tags).map((tag) => ({ tag: slug(tag) }));
   return paths;
 };
+
+export function generateMetadata({ params }: TagPageProps): Metadata {
+  const title = params.tag.split("-").join(" ");
+
+  return {
+    title: `${title} | Tags`,
+    description: `Posts tagged with ${title}`,
+  };
+}
 
 export default function TagPage({ params }: TagPageProps) {
   const { tag } = params;

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -3,9 +3,9 @@ import { Metadata } from "next";
 import { posts } from "#site/content";
 import { Tag } from "@/components/tag";
 
-const metadata: Metadata = {
+export const metadata: Metadata = {
   title: "Tags",
-  description: "Topic I've written about",
+  description: "Topics I've written about",
 };
 
 export default function TagsPage() {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -47,6 +47,11 @@ export function getPostsByTagSlug(posts: Array<Post>, tag: string) {
   })
 }
 
+export const siteConfig = {
+  name: "Igor Souza's Blog",
+  description: "Stunning things I've learned and want to share",
+}
+
 export const personalInfo = {
   "name": "Igor Souza",
   "fullName": "Igor Matheus Chagas de Souza",


### PR DESCRIPTION
Closes #9

## Summary

Every page in the app router rendered without a real `<title>` — the previous `metadata` objects in `app/page.tsx` and `app/tags/page.tsx` were local consts, never exported, so Next.js never picked them up, and dynamic routes (`[slug]`, `tags/[tag]`) either had a static placeholder title or none at all.

This adds proper per-page metadata using Next's App Router metadata API:

- `app/layout.tsx`: root default title (`"Igor Souza's Blog"`) and a `%s | Igor Souza's Blog` template for descendant routes.
- `app/page.tsx` (home): explicit `"Home | Igor Souza's Blog"`. Note: this page shares its route segment with the root layout, so the inherited `title.template` does not actually apply to it (a documented Next.js quirk — templates only propagate to *child* segments) — verified this empirically and built the title directly to avoid a silent bug.
- `app/tags/page.tsx`: `"Tags | Igor Souza's Blog"` (now actually exported).
- `app/tags/[tag]/page.tsx`: added `generateMetadata()` → `"<tag> | Tags | Igor Souza's Blog"`.
- `app/[slug]/page.tsx`: replaced the static placeholder with `generateMetadata()` that reads the post's `title`/`description` from Velite content (`content/*.mdx` frontmatter) → `"<Post Title> | Igor Souza's Blog"`.
- `lib/utils.ts`: added a small `siteConfig` (`name`, `description`) reused across layout/home page.

## Test plan

- [x] `npm run lint` — no warnings/errors
- [x] `npm run build` (after `npx velite build`) — compiles and generates all static pages successfully
- [x] Inspected generated static HTML in `.next/server/app/**/*.html` and confirmed distinct `<title>` per route, e.g.:
  - `/` → `Home | Igor Souza's Blog`
  - `/tags` → `Tags | Igor Souza's Blog`
  - `/tags/chroot` → `chroot | Tags | Igor Souza's Blog`
  - `/welcome` → `Welcome to the Blog! | Igor Souza's Blog`
  - `/we-need-to-talk-about-gil` → `We need to talk about GIL! | Igor Souza's Blog`

🤖 Generated with [Claude Code](https://claude.com/claude-code)