### PR TITLE
Fix blank page in dev mode by resolving theme flicker at the root

### DIFF
--- a/app/body-layout.tsx
+++ b/app/body-layout.tsx
@@ -11,7 +11,10 @@ export function BodyLayout({ children }: { children: React.ReactNode }) {
   const { theme } = useThemeContext();
 
   return (
-    <body className={`flex flex-col min-h-[100vh] container max-w-6xl ${inter.className} ${theme}`}>
+    <body
+      suppressHydrationWarning
+      className={`flex flex-col min-h-[100vh] container max-w-6xl ${inter.className} ${theme}`}
+    >
       <Header />
       <main className="flex-grow">{children}</main>
       <Footer />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,22 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function () {
+                try {
+                  var theme =
+                    localStorage.getItem("themePreference") ||
+                    (window.matchMedia("(prefers-color-scheme: dark)").matches
+                      ? "dark"
+                      : "light");
+                  document.documentElement.classList.add(theme);
+                } catch (e) {}
+              })();
+            `,
+          }}
+        />
         <link rel="icon" type="image/svg+xml" href="/blog/favicon.svg" />
       </head>
       <ThemeContextProvider>

--- a/context/index.tsx
+++ b/context/index.tsx
@@ -27,8 +27,6 @@ export default function ThemeContextProvider({ children }: { children: ReactNode
     localStorage.setItem("themePreference", choise)
   }, [])
 
-  if (!theme && process.env.NODE_ENV != "development") return null  // TODO: Find a way to fix this monstrosity!
-
   return (
     <ThemeContext.Provider value={{ theme, handleChangeTheme }}>
       {children}


### PR DESCRIPTION
Closes #10

## Summary

`ThemeContextProvider` (`context/index.tsx`) initialized `theme` as `undefined` and only rendered `children` once an effect determined the real theme, returning `null` in the meantime to avoid a light/dark flash on first paint. A `process.env.NODE_ENV != "development"` escape hatch had been bolted onto that check to work around `next dev`'s effect double-invocation / Fast Refresh remounts leaving `theme` stuck at `undefined` with no retry — which avoided the blank page but brought the flicker back in dev.

This replaces that with the standard `next-themes`-style pattern:

- `app/layout.tsx`: added a blocking inline `<script>` in `<head>` that runs synchronously before hydration, reads `localStorage.getItem("themePreference")`, falls back to `prefers-color-scheme`, and applies the resulting class to `document.documentElement` so the correct theme is present on first paint, with no flash.
- `context/index.tsx`: removed the `if (!theme && ...) return null` branch (and its TODO) entirely — the provider now always renders `children`. `determineTheme()` and the mount effect are unchanged, still driving the React-side theme state and the toggle button.
- `app/body-layout.tsx`: added `suppressHydrationWarning` to `<body>`, since its `className` legitimately differs between the server-rendered HTML (`theme` is `undefined` there) and the script-patched initial DOM until the effect settles — this is expected and not an actual bug.

## Test plan

- [x] `npm run dev`, loaded `/`, a post page, and `/tags` — all render full content immediately, no blank page.
- [x] Inspected server-rendered HTML for those routes — inline script present in `<head>`, `<body>` renders normally.
- [x] `npm run build` — succeeds, prerendered HTML for all routes looks normal (theme script embedded, no blank body).
- [x] `npm run lint` — no warnings or errors.