### PR TITLE
Add Playwright E2E suite with CI gate on pull requests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,38 @@
+name: E2E tests
+
+on:
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: npm run test:e2e
+        env:
+          CI: true
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,10 +10,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: "npm"
@@ -31,7 +31,7 @@ jobs:
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: playwright-report/

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
 
 # next.js
 /.next/

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,55 @@
+# Features & E2E coverage
+
+Every user-facing feature in this blog should have at least one Playwright
+scenario in `e2e/`. This file is the index: when you ship a feature, add a
+row here and a test alongside it. When you touch a feature, check the linked
+test still describes what it does.
+
+E2E tests run in `e2e/` via Playwright (`npm run test:e2e`), on pull requests
+(`.github/workflows/e2e.yml`), across four projects: Desktop and Mobile
+viewports, each in light and dark color scheme. A feature scenario doesn't
+need to special-case viewport/theme itself unless the feature's behavior
+actually differs between them (e.g. hidden-on-mobile elements, theme class
+assertions) — the project matrix runs every spec through all four
+combinations for free.
+
+| Feature | Introduced in | Covered by |
+|---|---|---|
+| Home page: post list sorted newest-first, tag sidebar with counts | 5e46d98 | `e2e/home.spec.ts` |
+| Header navigation (logo, Home, Blog, Tags) | 5e46d98, f7938a2 (mobile layout) | `e2e/navigation.spec.ts` |
+| Tags index page (all tags with counts) | 5e46d98 | `e2e/tags.spec.ts` |
+| Tag filter page (posts by tag, empty state, active-tag highlight) | 5e46d98 | `e2e/tags.spec.ts` |
+| Post page (title, description, tags, author, date, reading time) | 5e46d98 | `e2e/post.spec.ts` |
+| MDX content rendering (headings, code blocks, `Callout`, etc.) | 5e46d98 | `e2e/post.spec.ts` |
+| Scroll progress bar on post pages | 5e46d98 | `e2e/post.spec.ts` |
+| Footer (portfolio cross-links, socials, mail) | 5e46d98 | `e2e/footer.spec.ts` |
+| Mobile responsive layout | f7938a2 (#6) | `e2e/responsive.spec.ts` |
+| Favicon under `/blog` base path | d16327e (#7) | `e2e/responsive.spec.ts` |
+| Theme toggle (light/dark, persisted, OS-default) | 236a199 (#8), 9edd944 (#10) | `e2e/theme.spec.ts` |
+| Custom 404 page | — | `e2e/navigation.spec.ts` |
+| Per-page HTML `<title>` | bb437cf (#9) | `e2e/seo-titles.spec.ts` |
+| No blank/flash-of-empty-body on first paint (dev flicker regression) | 9edd944 (#10) | `e2e/theme.spec.ts` |
+
+## Adding a feature
+
+1. Write the Playwright scenario in `e2e/` (new file if it's a new area of
+   the site, otherwise add a test to the closest existing spec).
+2. Prefer structural/role-based assertions (`getByRole`, `getByText`) over
+   pixel coordinates or CSS class snapshots, so tests survive redesigns.
+3. If the feature is genuinely content-dependent (specific post titles,
+   tags), it's fine to assert on today's fixture content in `content/*.mdx`
+   — just know the test will need a matching update if that content changes.
+4. Add a row to the table above.
+5. Run `npm run test:e2e` locally before opening the PR (`npm run
+   test:e2e:ui` for the interactive runner while iterating).
+
+## Known gotcha: the `/blog` base path
+
+This site is deployed with `basePath: "/blog"` (`next.config.mjs`). In
+`playwright.config.ts`, `baseURL` is set to `http://127.0.0.1:<port>/blog/`
+**with a trailing slash**. Because of how `new URL(path, baseURL)`
+resolution works, every `page.goto(...)` call in this suite must use a
+**relative path with no leading slash** (`page.goto("tags/welcome")`, and
+`page.goto("")` for the home page) — a leading slash resets to the origin
+root and silently drops the `/blog` prefix, which manifests as a 404 that
+has nothing to do with your change.

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -64,7 +64,7 @@ export default async function PostPage({ params }: PostPageProps) {
       {post.description ? (
         <p className="text-xl mt-0 text-muted-foreground text-center sm:text-left">{post.description}</p>
       ) : null}
-      <div className="flex gap-2 mb-2">
+      <div className="flex flex-wrap gap-2 mb-2">
         {post.tags?.map((tag) => (
           <Tag tag={tag} key={tag} />
         ))}

--- a/components/post-item.tsx
+++ b/components/post-item.tsx
@@ -26,7 +26,7 @@ export function PostItem({
           <Link href={"/" + slug}>{title}</Link>
         </h2>
       </div>
-      <div className="flex gap-2">
+      <div className="flex flex-wrap gap-2">
         {tags?.map((tag) => (
           <Tag tag={tag} key={tag} />
         ))}

--- a/e2e/footer.spec.ts
+++ b/e2e/footer.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Footer", () => {
+  test("cross-links to Igor's portfolio site, socials, and the mail contact", async ({
+    page,
+  }) => {
+    await page.goto("");
+    const footer = page.locator("footer");
+
+    await expect(footer.getByRole("link", { name: "Home" })).toHaveAttribute(
+      "href",
+      "https://igormcsouza.github.io/"
+    );
+    await expect(footer.getByRole("link", { name: "About" })).toHaveAttribute(
+      "href",
+      "https://igormcsouza.github.io/#about"
+    );
+    await expect(
+      footer.getByRole("link", { name: "Projects" })
+    ).toHaveAttribute("href", "https://igormcsouza.github.io/#projects");
+    await expect(footer.getByRole("link", { name: "News" })).toHaveAttribute(
+      "href",
+      "https://igormcsouza.github.io/#news"
+    );
+
+    await expect(footer.getByRole("link", { name: "GitHub" })).toHaveAttribute(
+      "href",
+      "https://github.com/igormcsouza"
+    );
+    await expect(footer.getByRole("link", { name: "Twitter" })).toHaveAttribute(
+      "href",
+      "https://twitter.com/igormcsouza"
+    );
+    await expect(
+      footer.getByRole("link", { name: "LinkedIn" })
+    ).toHaveAttribute("href", "https://linkedin.com/in/igormcsouza");
+    await expect(
+      footer.getByRole("link", { name: "Instagram" })
+    ).toHaveAttribute("href", "https://www.instagram.com/igormcsouza/");
+
+    await expect(footer.getByRole("link", { name: "mail" })).toHaveAttribute(
+      "href",
+      "mailto:igormcsouza@gmail.com"
+    );
+
+    await expect(
+      footer.getByText(`© ${new Date().getFullYear()} Igor Souza. All rights reserved.`)
+    ).toBeVisible();
+  });
+});

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Home page", () => {
+  test("shows the site heading and a non-empty, date-sorted post list", async ({
+    page,
+  }) => {
+    await page.goto("");
+    await expect(page).toHaveTitle(/Home \| Igor Souza's Blog/);
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Igor Souza's Blog" })
+    ).toBeVisible();
+
+    const posts = page.locator("main article");
+    await expect(posts.first()).toBeVisible();
+
+    const dates = await posts.locator("time").allTextContents();
+    const parsed = dates.map((d) => new Date(d).getTime());
+    const sorted = [...parsed].sort((a, b) => b - a);
+    expect(parsed).toEqual(sorted);
+  });
+
+  test("each post card links to its post and shows title, tags, and date", async ({
+    page,
+  }) => {
+    await page.goto("");
+    const firstPost = page.locator("main article").first();
+
+    await expect(firstPost.getByRole("heading", { level: 2 })).toBeVisible();
+    await expect(firstPost.locator("time")).toBeVisible();
+    await expect(
+      firstPost.getByRole("link", { name: /read more/i })
+    ).toBeVisible();
+
+    const titleLink = firstPost.getByRole("heading", { level: 2 }).getByRole("link");
+    const href = await titleLink.getAttribute("href");
+    await titleLink.click();
+    await expect(page).toHaveURL(new RegExp(`${href}$`));
+  });
+
+  test("sidebar lists every tag with its post count", async ({ page }) => {
+    await page.goto("");
+    const tagsCard = page.locator("div.rounded-lg", { has: page.getByRole("heading", { name: "Tags" }) });
+    const tagLinks = tagsCard.getByRole("link");
+    await expect(tagLinks.first()).toBeVisible();
+
+    const count = await tagLinks.count();
+    for (let i = 0; i < count; i++) {
+      await expect(tagLinks.nth(i)).toHaveText(/\(\d+\)$/);
+    }
+  });
+});

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Header navigation", () => {
+  test("Blog link goes to the blog index", async ({ page }) => {
+    await page.goto("tags");
+    await page.getByRole("navigation").getByRole("link", { name: "Blog" }).click();
+    await expect(page).toHaveURL(/\/blog\/?$/);
+    await expect(page).toHaveTitle(/Home \| Igor Souza's Blog/);
+  });
+
+  test("Tags link goes to the tags index", async ({ page }) => {
+    await page.goto("");
+    await page.getByRole("navigation").getByRole("link", { name: "Tags" }).click();
+    await expect(page).toHaveURL(/\/blog\/tags$/);
+    await expect(page.getByRole("heading", { level: 1, name: "Tags" })).toBeVisible();
+  });
+
+  test("Home link points to Igor's personal portfolio site, not the blog", async ({
+    page,
+  }) => {
+    await page.goto("");
+    const homeLink = page.getByRole("navigation").getByRole("link", { name: "Home" });
+    await expect(homeLink).toHaveAttribute("href", "https://igormcsouza.github.io/");
+  });
+
+  test("logo links back to the blog home", async ({ page }) => {
+    // The logo is hidden below Tailwind's `sm` breakpoint (see
+    // components/header.tsx), so on mobile viewports we only assert it is
+    // present in the DOM rather than requiring it to be visible.
+    await page.goto("tags");
+    const logoLink = page.locator("header a.hidden.sm\\:inline-block");
+    await expect(logoLink).toBeAttached();
+
+    const viewport = page.viewportSize();
+    if (viewport && viewport.width >= 640) {
+      await expect(logoLink).toBeVisible();
+      await logoLink.click();
+      await expect(page).toHaveURL(/\/blog\/?$/);
+    }
+  });
+});
+
+test.describe("404 page", () => {
+  test("unknown routes render a not-found page instead of crashing", async ({
+    page,
+  }) => {
+    const response = await page.goto("this-post-does-not-exist");
+    expect(response?.status()).toBe(404);
+    await expect(page.getByText("404")).toBeVisible();
+    await expect(page.getByText(/page could not be found/i)).toBeVisible();
+  });
+});

--- a/e2e/post.spec.ts
+++ b/e2e/post.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "@playwright/test";
+
+const POST_URL = "welcome";
+
+test.describe("Post page", () => {
+  test("renders title, description, tags, author, date, and reading time", async ({
+    page,
+  }) => {
+    await page.goto(POST_URL);
+    await expect(page).toHaveTitle(/Welcome to the Blog! \| Igor Souza's Blog/);
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Welcome to the Blog!" })
+    ).toBeVisible();
+    await expect(
+      page.getByText("It's my pleasure to say to you all a warm welcome to my blog!")
+    ).toBeVisible();
+
+    await expect(page.getByRole("link", { name: "welcome" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "introduction" })).toBeVisible();
+
+    await expect(page.getByText("Igor Souza", { exact: true })).toBeVisible();
+    await expect(page.locator("time")).toBeVisible();
+    await expect(page.getByText(/min read/)).toBeVisible();
+  });
+
+  test("renders MDX body content, including custom components like Callout", async ({
+    page,
+  }) => {
+    await page.goto(POST_URL);
+    await expect(
+      page.getByText(/childhood dream coming true/i)
+    ).toBeVisible();
+    await expect(
+      page.getByText(/Here you will find a lot of knowledge/i)
+    ).toBeVisible();
+  });
+
+  test("code blocks in a post render with syntax highlighting and horizontal scroll for long lines", async ({
+    page,
+  }) => {
+    await page.goto("containerization-a-chroot-with-steroids");
+    const codeBlock = page.locator("pre").first();
+    await expect(codeBlock).toBeVisible();
+
+    const overflowX = await codeBlock.evaluate(
+      (el) => getComputedStyle(el).overflowX
+    );
+    expect(overflowX).toBe("auto");
+  });
+
+  test("scroll progress bar advances as the reader scrolls the post", async ({
+    page,
+  }) => {
+    await page.goto("containerization-a-chroot-with-steroids");
+    const progressBar = page.locator("div.fixed.top-0.left-0.h-1");
+    await expect(progressBar).toBeAttached();
+
+    const widthBefore = await progressBar.evaluate(
+      (el) => (el as HTMLElement).style.width
+    );
+
+    await page.mouse.wheel(0, 4000);
+    await page.waitForTimeout(200);
+
+    const widthAfter = await progressBar.evaluate(
+      (el) => (el as HTMLElement).style.width
+    );
+
+    expect(parseFloat(widthAfter)).toBeGreaterThan(parseFloat(widthBefore) || 0);
+  });
+
+  test("tag chip on a post links to that tag's filter page", async ({
+    page,
+  }) => {
+    await page.goto(POST_URL);
+    await page.getByRole("link", { name: "welcome" }).click();
+    await expect(page).toHaveURL(/\/blog\/tags\/welcome$/);
+  });
+});

--- a/e2e/responsive.spec.ts
+++ b/e2e/responsive.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Responsive layout", () => {
+  test("home page has no horizontal overflow at the current viewport", async ({
+    page,
+  }) => {
+    await page.goto("");
+    const hasHorizontalScroll = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth
+    );
+    expect(hasHorizontalScroll).toBe(false);
+  });
+
+  test("post page has no horizontal overflow at the current viewport", async ({
+    page,
+  }) => {
+    await page.goto("containerization-a-chroot-with-steroids");
+    const hasHorizontalScroll = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth
+    );
+    expect(hasHorizontalScroll).toBe(false);
+  });
+
+  test("the tag sidebar stacks below the post list on narrow viewports", async ({
+    page,
+  }) => {
+    const viewport = page.viewportSize();
+    test.skip(!viewport || viewport.width >= 640, "desktop-only layout check");
+
+    await page.goto("");
+    const postList = page.locator("main .col-span-12").first();
+    const tagsCard = page.locator("div.rounded-lg", { has: page.getByRole("heading", { name: "Tags" }) });
+
+    const postBox = await postList.boundingBox();
+    const tagsBox = await tagsCard.boundingBox();
+    expect(postBox && tagsBox && tagsBox.y).toBeGreaterThan(
+      (postBox?.y ?? 0) + (postBox?.height ?? 0) - 50
+    );
+  });
+
+  test("favicon resolves under the /blog base path", async ({ page }) => {
+    await page.goto("");
+    const iconHref = await page
+      .locator("link[rel='icon']")
+      .getAttribute("href");
+    expect(iconHref).toBe("/blog/favicon.svg");
+
+    const response = await page.request.get(iconHref!);
+    expect(response.status()).toBe(200);
+  });
+});

--- a/e2e/seo-titles.spec.ts
+++ b/e2e/seo-titles.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+
+const ROUTES: Array<[string, RegExp]> = [
+  ["", /^Home \| Igor Souza's Blog$/],
+  ["tags", /^Tags \| Igor Souza's Blog$/],
+  ["tags/welcome", /^welcome \| Tags \| Igor Souza's Blog$/],
+  ["welcome", /^Welcome to the Blog! \| Igor Souza's Blog$/],
+];
+
+test.describe("Per-page HTML titles (regression for #9)", () => {
+  for (const [path, expected] of ROUTES) {
+    test(`"${path}" has a distinct, correctly formatted title`, async ({
+      page,
+    }) => {
+      await page.goto(path);
+      await expect(page).toHaveTitle(expected);
+    });
+  }
+
+  test("titles across routes are all unique", async ({ page }) => {
+    const titles: string[] = [];
+    for (const [path] of ROUTES) {
+      await page.goto(path);
+      titles.push(await page.title());
+    }
+    expect(new Set(titles).size).toBe(titles.length);
+  });
+});

--- a/e2e/tags.spec.ts
+++ b/e2e/tags.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Tags index page", () => {
+  test("lists every tag with a post count and links to its filter page", async ({
+    page,
+  }) => {
+    await page.goto("tags");
+    await expect(page).toHaveTitle(/Tags \| Igor Souza's Blog/);
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Tags" })
+    ).toBeVisible();
+
+    const tagLink = page.getByRole("link", { name: /welcome \(\d+\)/i });
+    await expect(tagLink).toBeVisible();
+    await tagLink.click();
+    await expect(page).toHaveURL(/\/blog\/tags\/welcome$/);
+  });
+});
+
+test.describe("Tag filter page", () => {
+  test("shows only posts carrying the selected tag, and highlights it in the sidebar", async ({
+    page,
+  }) => {
+    await page.goto("tags/welcome");
+    await expect(
+      page.getByRole("heading", { level: 1, name: "welcome" })
+    ).toBeVisible();
+
+    const posts = page.locator("main article");
+    await expect(posts).toHaveCount(1);
+    await expect(posts.first().getByRole("heading", { level: 2 })).toHaveText(
+      "Welcome to the Blog!"
+    );
+
+    const tagsCard = page.locator("div.rounded-lg", { has: page.getByRole("heading", { name: "Tags" }) });
+    const currentTag = tagsCard.getByRole("link", { name: /welcome \(\d+\)/i });
+    await expect(currentTag).toBeVisible();
+  });
+
+  test("a tag slug with no matching posts shows the empty state instead of crashing", async ({
+    page,
+  }) => {
+    await page.goto("tags/does-not-exist");
+    await expect(page.getByText("Nothing to see here yet")).toBeVisible();
+  });
+});

--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Theme toggle", () => {
+  test("defaults to the OS color scheme when no preference is stored", async ({
+    page,
+  }) => {
+    await page.goto("");
+    const expected = await page.evaluate(
+      () => (matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")
+    );
+    await expect(page.locator("body")).toHaveClass(new RegExp(expected));
+  });
+
+  test("clicking the toggle switches the theme and the choice survives a reload", async ({
+    page,
+  }) => {
+    await page.goto("");
+    const body = page.locator("body");
+    // Theme is resolved client-side after mount (see context/index.tsx), so
+    // wait for that to settle before snapshotting "before" - reading too
+    // early can catch the transient pre-hydration class and desync from
+    // what the toggle button actually flips.
+    await page.waitForFunction(() =>
+      /\b(light|dark)\b/.test(document.body.className)
+    );
+    const before = /\bdark\b/.test((await body.getAttribute("class")) ?? "")
+      ? "dark"
+      : "light";
+    const after = before === "dark" ? "light" : "dark";
+
+    await page.getByRole("button", { name: /toggle theme/i }).click();
+    await expect(body).toHaveClass(new RegExp(after));
+    await expect(body).not.toHaveClass(new RegExp(before));
+
+    await page.reload();
+    await expect(body).toHaveClass(new RegExp(after));
+
+    const stored = await page.evaluate(() =>
+      localStorage.getItem("themePreference")
+    );
+    expect(stored).toBe(after);
+  });
+
+  test("page content is visible immediately on first load, in both themes (regression for #10)", async ({
+    page,
+  }) => {
+    // Guards against the dev-mode "blank page" bug (issue #10): the theme
+    // provider must never render a null/empty tree while it figures out the
+    // active theme, in any color scheme.
+    await page.goto("");
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Igor Souza's Blog" })
+    ).toBeVisible();
+    await expect(page.locator("main article").first()).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/typography": "^0.5.12",
         "@types/node": "^20",
         "@types/react": "^18",
@@ -1866,6 +1867,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -6937,6 +6954,53 @@
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:e2e": "velite build && next build",
     "start": "next start",
     "lint": "next lint",
-    "velite": "velite dev"
+    "velite": "velite dev",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@emotion/react": "^11.11.4",
@@ -26,6 +29,7 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/typography": "^0.5.12",
     "@types/node": "^20",
     "@types/react": "^18",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,47 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = process.env.PORT ? Number(process.env.PORT) : 4173;
+// Trailing slash matters: combined with relative (non-leading-slash) paths
+// in tests, this makes `new URL(path, baseURL)` resolve *under* the /blog
+// basePath instead of replacing it. See README/e2e docs for the gotcha.
+const baseURL = `http://127.0.0.1:${PORT}/blog/`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI
+    ? [["github"], ["html", { open: "never" }]]
+    : "html",
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  webServer: {
+    command: `npm run build:e2e && npm run start -- -p ${PORT}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+  projects: [
+    {
+      name: "Desktop Chrome - Light",
+      use: { ...devices["Desktop Chrome"], colorScheme: "light" },
+    },
+    {
+      name: "Desktop Chrome - Dark",
+      use: { ...devices["Desktop Chrome"], colorScheme: "dark" },
+    },
+    {
+      name: "Mobile Chrome - Light",
+      use: { ...devices["Pixel 5"], colorScheme: "light" },
+    },
+    {
+      name: "Mobile Chrome - Dark",
+      use: { ...devices["Pixel 5"], colorScheme: "dark" },
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- Adds a Playwright E2E suite (`e2e/`) covering every current feature: home/tags/post pages, header nav, theme toggle, footer, custom 404, per-page titles, scroll progress, MDX content rendering.
- Runs across 4 projects: Desktop/Mobile viewport × light/dark theme, so every scenario gets responsive + theme coverage for free.
- New CI workflow `.github/workflows/e2e.yml` runs the suite on every pull request.
- `FEATURES.md` tracks the feature → test mapping and documents a `/blog` basePath gotcha for `page.goto()` calls (leading slash resets to origin root and silently drops the basePath — cost me most of the debugging time here).
- Along the way, the new responsive tests caught two real pre-existing bugs: the tag-chip rows on `post-item.tsx` and the post page header (`app/[slug]/page.tsx`) were missing `flex-wrap`, causing horizontal page overflow on narrow viewports when a post has 3+ tags. Fixed both (one-line each).

## Test plan
- [x] `npm run test:e2e` — 114 passed, 2 skipped (desktop-only checks correctly skipped on mobile projects), run from a clean build
- [x] `npx next lint` — no warnings/errors
- [x] Verified the CI workflow installs Playwright + chromium and runs `npm run test:e2e` with `CI=true`