### PR TITLE
Add blog post: Async vs. Threading: The Battle for Supremacy

### DIFF
--- a/content/async-vs-threading-the-battle-for-supremacy.mdx
+++ b/content/async-vs-threading-the-battle-for-supremacy.mdx
@@ -8,23 +8,23 @@ tags: ["python", "asyncio", "threading", "concurrency", "fastapi"]
 ---
 Lately it feels like every FastAPI service I open has `async def` sprinkled on every single endpoint, whether it's fetching a row from Postgres or just returning `{"status": "ok"}`. I've started asking people why, and the honest answer is almost always the same: "because it's faster, right?". That's not really an answer, it's a guess, and it's the same half-understanding that made people call Python "single-threaded" in my last post.
 
-So let's fix that. This post picks up exactly where [We need to talk about GIL!](/blog/we-need-to-talk-about-gil) left off, and puts Python's two concurrency models, `threading` and `asyncio`, in the ring together. By the end you'll know exactly when threads win, when async wins, and — just as important — when neither of them can help you at all.
+So let's fix that. This post picks up exactly where [We need to talk about GIL!](/blog/we-need-to-talk-about-gil) left off, and puts Python's two concurrency models, `threading` and `asyncio`, in the ring together. By the end you'll know exactly when threads win, when async wins, and, just as important, when neither of them can help you at all.
 
 ## Previously, on the GIL...
 
 Quick recap, three facts, no rehash:
 
 1. The Global Interpreter Lock means only one thread executes Python bytecode at a time.
-2. The GIL is **released whenever a thread blocks on I/O** — that loophole is the whole reason both threading and asyncio exist.
+2. The GIL is **released whenever a thread blocks on I/O**, that loophole is the whole reason both threading and asyncio exist.
 3. CPU-bound work gets no help from either of them. That's `multiprocessing` territory, and I'm not repeating that post here.
 
 <Callout icon="💡" type="informative">
-If "GIL", "mutex" or "I/O-bound" don't ring a bell yet, go read [We need to talk about GIL!](/blog/we-need-to-talk-about-gil) first. This post assumes you already know what the GIL is and why it exists — here we only care about what you can build around it.
+If "GIL", "mutex" or "I/O-bound" don't ring a bell yet, go read [We need to talk about GIL!](/blog/we-need-to-talk-about-gil) first. This post assumes you already know what the GIL is and why it exists, here we only care about what you can build around it.
 </Callout>
 
 ## The real enemy: waiting
 
-Before comparing tools, let's name the actual problem they're both trying to solve. Open any typical web request in a profiler and you'll notice something humbling: your CPU barely does anything. The vast majority of the wall-clock time is spent waiting — for the database to answer a query, for a downstream HTTP API to respond, for a disk read to finish. The process isn't computing, it's just parked.
+Before comparing tools, let's name the actual problem they're both trying to solve. Open any typical web request in a profiler and you'll notice something humbling: your CPU barely does anything. The vast majority of the wall-clock time is spent waiting, for the database to answer a query, for a downstream HTTP API to respond, for a disk read to finish. The process isn't computing, it's just parked.
 
 This is the split you need in your head from now on: **CPU-bound** work (parsing, hashing, image processing, machine learning inference) actually keeps a core busy the whole time. **I/O-bound** work spends almost all of its time blocked, waiting on something that isn't the CPU at all. Concurrency in a Python web service is, in the overwhelming majority of cases, about the second kind. It's not about doing more computation, it's about not standing still while you wait.
 
@@ -260,14 +260,14 @@ The one-line takeaway of this entire post: <code>async</code> does not make your
 
 There's no real "supremacy" here, the battle framing was always a bit of a trick. Threading and asyncio solve the exact same problem, idle time spent waiting, with opposite trade-offs: threads buy you compatibility with the code you already have at the cost of scale and the need for locks; asyncio buys you scale at the cost of rewriting your dependencies and a sharper failure mode when something blocks by accident. FastAPI's actual genius isn't "async is faster", it's letting you choose the right tool per endpoint instead of forcing one model on your whole application.
 
-Pick based on what your task is actually doing, not on what's fashionable to type. And keep an eye on free-threaded Python (PEP 703, now shipping as an experimental build) — it's already starting to shift these trade-offs again, which might just be the topic for post number three.
+Pick based on what your task is actually doing, not on what's fashionable to type. And keep an eye on free-threaded Python (PEP 703, now shipping as an experimental build), it's already starting to shift these trade-offs again, which might just be the topic for post number three.
 
 ### Further Reading
-- [FastAPI Best Practices — zhanymkanov](https://github.com/zhanymkanov/fastapi-best-practices)
-- [asyncio — Asynchronous I/O (Python docs)](https://docs.python.org/3/library/asyncio.html)
-- [threading — Thread-based parallelism (Python docs)](https://docs.python.org/3/library/threading.html)
-- [concurrent.futures — Launching parallel tasks (Python docs)](https://docs.python.org/3/library/concurrent.futures.html)
-- [FastAPI docs — Concurrency and async / await](https://fastapi.tiangolo.com/async/)
+- [FastAPI Best Practices, zhanymkanov](https://github.com/zhanymkanov/fastapi-best-practices)
+- [asyncio, Asynchronous I/O (Python docs)](https://docs.python.org/3/library/asyncio.html)
+- [threading, Thread-based parallelism (Python docs)](https://docs.python.org/3/library/threading.html)
+- [concurrent.futures, Launching parallel tasks (Python docs)](https://docs.python.org/3/library/concurrent.futures.html)
+- [FastAPI docs, Concurrency and async / await](https://fastapi.tiangolo.com/async/)
 - [We need to talk about GIL!](/blog/we-need-to-talk-about-gil)
 
 As always: profile first, then pick the tool, the fastest concurrency model is the one that actually matches what your code is waiting for.

--- a/content/async-vs-threading-the-battle-for-supremacy.mdx
+++ b/content/async-vs-threading-the-battle-for-supremacy.mdx
@@ -145,6 +145,30 @@ One `time.sleep`, one plain `requests.get`, one heavy pandas transformation insi
 
 <img src="/blog/static/async-vs-threading-the-battle-for-supremacy/threads-vs-event-loop.svg" alt="Side by side: three thread lanes taking turns holding the GIL versus one event loop handing off between tasks parked at await points" />
 
+### What actually yields, at the bottom of the chain
+
+There's a question hiding in that last example: you can `await` all day inside your own `async def` functions, chaining calls ten levels deep, and none of that, by itself, hands control back to the event loop. `await` on a plain coroutine just resumes it and runs it to its own next `await`, in the same step, no different from a regular function call. The real handoff to the loop happens exactly once per suspension, and only when the chain bottoms out in something that isn't a coroutine at all: an `asyncio.Future`.
+
+A `Future` is `__await__`-able, and its implementation looks roughly like this:
+
+```python showLineNumbers
+def __await__(self):
+    if not self.done():
+        self._asyncio_future_blocking = True
+        yield self          # the one real suspension point
+    return self.result()
+```
+
+That `yield` is the only actual yield in the entire chain. Every `await` you write on a coroutine just walks down the call stack looking for it. When the `Task` running your coroutine hits that `yield`, it registers a callback with the loop, via `loop.add_reader` for a socket, `loop.call_later` for a timer, and returns control, letting the loop run something else until the Future resolves and the callback reschedules your `Task`.
+
+`asyncio.sleep()` and every async I/O call (`httpx`, `asyncpg`, raw sockets through `loop.sock_recv`) end in exactly this pattern: create a `Future`, hand it to the loop, `yield` it, get woken up later. That's why `time.sleep()` inside a coroutine never yields anything: it isn't a `Future`, it's not hooked into the loop, it's just the CPU spinning until the call returns, with no `yield` anywhere for the `Task` to catch.
+
+So writing a truly cooperative async function takes more than making the outermost call `async def`. Every layer, all the way down, has to eventually `await` something that resolves to one of these loop-registered `Future`s, not a computation that merely happens to live inside a coroutine.
+
+<Callout icon="💡" type="informative">
+Quick gut check: trace a coroutine's call chain to the very bottom. If it doesn't end in an <code>await</code> on I/O, a timer, or an explicit <code>await asyncio.sleep(0)</code>, it never actually yields, no matter how many <code>async def</code>s wrap it along the way.
+</Callout>
+
 ## Head to head
 
 Neither column below says "runs Python in parallel", because neither does, the GIL still guarantees that. This is purely about who manages the waiting better.

--- a/content/async-vs-threading-the-battle-for-supremacy.mdx
+++ b/content/async-vs-threading-the-battle-for-supremacy.mdx
@@ -1,0 +1,273 @@
+---
+title: "Async vs. Threading: The Battle for Supremacy"
+description: FastAPI made everyone write async def, but do you know why? Let's settle the fight between Python's two concurrency models.
+author: Igor Souza
+date: 2026-07-19
+published: true
+tags: ["python", "asyncio", "threading", "concurrency", "fastapi"]
+---
+Lately it feels like every FastAPI service I open has `async def` sprinkled on every single endpoint, whether it's fetching a row from Postgres or just returning `{"status": "ok"}`. I've started asking people why, and the honest answer is almost always the same: "because it's faster, right?". That's not really an answer, it's a guess, and it's the same half-understanding that made people call Python "single-threaded" in my last post.
+
+So let's fix that. This post picks up exactly where [We need to talk about GIL!](/blog/we-need-to-talk-about-gil) left off, and puts Python's two concurrency models, `threading` and `asyncio`, in the ring together. By the end you'll know exactly when threads win, when async wins, and — just as important — when neither of them can help you at all.
+
+## Previously, on the GIL...
+
+Quick recap, three facts, no rehash:
+
+1. The Global Interpreter Lock means only one thread executes Python bytecode at a time.
+2. The GIL is **released whenever a thread blocks on I/O** — that loophole is the whole reason both threading and asyncio exist.
+3. CPU-bound work gets no help from either of them. That's `multiprocessing` territory, and I'm not repeating that post here.
+
+<Callout icon="💡" type="informative">
+If "GIL", "mutex" or "I/O-bound" don't ring a bell yet, go read [We need to talk about GIL!](/blog/we-need-to-talk-about-gil) first. This post assumes you already know what the GIL is and why it exists — here we only care about what you can build around it.
+</Callout>
+
+## The real enemy: waiting
+
+Before comparing tools, let's name the actual problem they're both trying to solve. Open any typical web request in a profiler and you'll notice something humbling: your CPU barely does anything. The vast majority of the wall-clock time is spent waiting — for the database to answer a query, for a downstream HTTP API to respond, for a disk read to finish. The process isn't computing, it's just parked.
+
+This is the split you need in your head from now on: **CPU-bound** work (parsing, hashing, image processing, machine learning inference) actually keeps a core busy the whole time. **I/O-bound** work spends almost all of its time blocked, waiting on something that isn't the CPU at all. Concurrency in a Python web service is, in the overwhelming majority of cases, about the second kind. It's not about doing more computation, it's about not standing still while you wait.
+
+<img src="/blog/static/async-vs-threading-the-battle-for-supremacy/request-timeline.svg" alt="Timeline of a single request: a short CPU burst, a long wait on network or database, and a final short CPU burst" />
+
+Here's the baseline nobody wants to admit they still write: fetch three URLs, one after another, and just... wait.
+
+```python {6,7,8} showLineNumbers
+import time
+import requests
+
+def fetch(url):
+    start = time.perf_counter()
+    response = requests.get(url)
+    elapsed = time.perf_counter() - start
+    print(f"{url} -> {response.status_code} in {elapsed:.2f}s")
+    return response
+
+urls = [
+    "https://httpbin.org/delay/1",
+    "https://httpbin.org/delay/1",
+    "https://httpbin.org/delay/1",
+]
+
+start = time.perf_counter()
+for url in urls:
+    fetch(url)
+print(f"Total: {time.perf_counter() - start:.2f}s")
+```
+
+Three requests, each taking about a second, run one after another. Total: roughly 3 seconds. Your CPU was free for 2.9 of those 3 seconds and did nothing with the time. This is exactly the gap threading and asyncio exist to close.
+
+## Contender #1: Threading
+
+Threads are managed by the operating system, and the OS is **preemptive**: it can pause a thread and hand the CPU to another one at basically any point, whether the thread likes it or not. In CPython, when a thread blocks on I/O, it releases the GIL, and the OS scheduler is free to run a different thread in the meantime. The killer feature here is that this works with code you already have. `requests`, `psycopg2`, any classic blocking library, just works, unmodified, inside a thread.
+
+```python {1,15} showLineNumbers
+from concurrent.futures import ThreadPoolExecutor
+import time
+import requests
+
+def fetch(url):
+    start = time.perf_counter()
+    response = requests.get(url)
+    elapsed = time.perf_counter() - start
+    print(f"{url} -> {response.status_code} in {elapsed:.2f}s")
+    return response
+
+urls = ["https://httpbin.org/delay/1"] * 3
+
+start = time.perf_counter()
+with ThreadPoolExecutor(max_workers=3) as executor:
+    list(executor.map(fetch, urls))
+print(f"Total: {time.perf_counter() - start:.2f}s")
+```
+
+Same `fetch` function, not a single line changed inside it. Total time now: roughly 1 second, the duration of the *slowest* request, because all three were in flight waiting at the same time.
+
+That convenience has a price. Every thread carries its own stack (megabytes, not bytes), and the OS has to context-switch between them, so threads don't scale to tens of thousands of concurrent tasks the way we'd like. And because the OS can interrupt a thread between literally any two bytecodes, any state shared across threads needs explicit protection.
+
+<Callout icon="⚡" type="warning">
+Preemption means you never control exactly when a switch happens. If two threads touch the same shared variable without a `Lock`, you get the exact race condition from the GIL post's counter example: two threads incrementing the same number 1,000,000 times each, and the final result isn't 2,000,000. Threads buy you free concurrency for I/O; they don't buy you free correctness for shared state.
+</Callout>
+
+## Contender #2: Asyncio
+
+Asyncio flips the whole model around. Instead of many OS threads, you get **one thread and one event loop**, and instead of the OS preempting tasks whenever it feels like it, tasks **volunteer** to pause, at every `await`. This is called cooperative scheduling.
+
+<Callout icon="💡" type="informative">
+The mental model that matters here: **preemptive** means the OS taps a task on the shoulder and says "your turn is over", at any point, without asking. **Cooperative** means a task runs uninterrupted until it explicitly says `await`, which really means "I'm about to wait on something anyway, someone else can go ahead." Nothing switches unless a task chooses to yield.
+</Callout>
+
+The event loop keeps a queue of tasks. When a task hits an `await` on something slow (a socket read, a timer), the loop parks it and picks up the next ready task. When the slow thing finishes, the parked task goes back in the queue. Because tasks are just lightweight objects, not OS threads, you can have tens of thousands of them alive at once for a fraction of the memory cost.
+
+```python {1,4,6,10,15} showLineNumbers
+import asyncio
+import httpx
+
+async def fetch(client, url):
+    start = asyncio.get_event_loop().time()
+    response = await client.get(url)
+    elapsed = asyncio.get_event_loop().time() - start
+    print(f"{url} -> {response.status_code} in {elapsed:.2f}s")
+    return response
+
+async def main():
+    urls = ["https://httpbin.org/delay/1"] * 3
+    async with httpx.AsyncClient() as client:
+        await asyncio.gather(*(fetch(client, url) for url in urls))
+
+asyncio.run(main())
+```
+
+Same result as the threaded version, roughly 1 second total, but this approach holds up just as well at 10,000 URLs, where spinning up 10,000 threads simply isn't realistic.
+
+The catch is that this only works if everything in the call chain is async-native. Async is viral: `requests` becomes `httpx`, `psycopg2` becomes `asyncpg`, and so on, all the way down. And there's a sharper trap waiting for the ones who don't switch libraries:
+
+```python {5} showLineNumbers
+import asyncio
+import time
+
+async def broken_task(name):
+    print(f"{name} starting")
+    time.sleep(1)  # should be: await asyncio.sleep(1)
+    print(f"{name} done")
+
+async def main():
+    await asyncio.gather(broken_task("A"), broken_task("B"))
+
+asyncio.run(main())
+```
+
+Swap `await asyncio.sleep(1)` for plain `time.sleep(1)` and the two tasks that should have finished in 1 second together now take 2, run one after another. `time.sleep` doesn't yield, so nothing else on the loop gets a turn until it returns.
+
+<Callout icon="⚡" type="danger">
+One `time.sleep`, one plain `requests.get`, one heavy pandas transformation inside a coroutine, and your entire event loop stops. Not just that task, every task sharing that loop. This is the single most common async bug in production, and we'll see it show up again, wearing a FastAPI costume, in the next section.
+</Callout>
+
+<img src="/blog/static/async-vs-threading-the-battle-for-supremacy/threads-vs-event-loop.svg" alt="Side by side: three thread lanes taking turns holding the GIL versus one event loop handing off between tasks parked at await points" />
+
+## Head to head
+
+Neither column below says "runs Python in parallel", because neither does, the GIL still guarantees that. This is purely about who manages the waiting better.
+
+<table>
+  <thead>
+  <tr>
+    <th>Aspect</th>
+    <th>Threading</th>
+    <th>Asyncio</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>Scheduling</td>
+    <td>Preemptive (OS decides)</td>
+    <td>Cooperative (task yields at <code>await</code>)</td>
+  </tr>
+  <tr>
+    <td>Concurrency unit cost</td>
+    <td>OS thread, megabytes of stack each</td>
+    <td>Coroutine/task, kilobytes each</td>
+  </tr>
+  <tr>
+    <td>Realistic scale</td>
+    <td>Dozens to a few hundred</td>
+    <td>Tens of thousands</td>
+  </tr>
+  <tr>
+    <td>Works with blocking libraries</td>
+    <td>Yes, unchanged</td>
+    <td>No, needs async-native replacements</td>
+  </tr>
+  <tr>
+    <td>Race conditions</td>
+    <td>Likely without <code>Lock</code>s</td>
+    <td>Rare, switches only happen at <code>await</code></td>
+  </tr>
+  <tr>
+    <td>Effect of one slow/blocking call</td>
+    <td>Only that thread stalls</td>
+    <td>The entire loop stalls</td>
+  </tr>
+  <tr>
+    <td>CPU-bound parallelism</td>
+    <td>No (GIL)</td>
+    <td>No (GIL, and single-threaded anyway)</td>
+  </tr>
+  </tbody>
+</table>
+
+## FastAPI enters the room
+
+This is where the original question finally gets an answer. FastAPI, through Starlette and AnyIO underneath it, actually runs *both* models at once and picks per endpoint. An `async def` endpoint runs directly on the event loop. A plain `def` endpoint is automatically dispatched to an external threadpool, precisely so it can't block the loop. A synchronous endpoint isn't a mistake, it's threading, managed for you.
+
+```python {6,7,8,9,10,11,12,13} showLineNumbers
+from fastapi import FastAPI
+import httpx
+import requests
+
+app = FastAPI()
+
+@app.get("/sync")            # dispatched to the threadpool
+def call_service_sync():
+    r = requests.get("https://api.example.com/data")
+    return r.json()
+
+@app.get("/async")           # runs directly on the event loop
+async def call_service_async():
+    async with httpx.AsyncClient() as client:
+        r = await client.get("https://api.example.com/data")
+    return r.json()
+```
+
+Both endpoints are correct Python. Under low load you won't notice a difference. Under high concurrency you will: a parked coroutine costs almost nothing, so a worker running `/async` can hold thousands of in-flight requests. The `/sync` endpoint is bounded by the threadpool.
+
+<Callout icon="💡" type="informative">
+AnyIO's default threadpool caps out around 40 threads per worker process. That's your hard ceiling for concurrent `def` requests on a single worker; the 41st simply queues behind the others. The event loop's ceiling for `async def` is, in practice, however much memory you have. Check your AnyIO/Starlette version if this number matters to your capacity planning, it's a tunable, not a law of physics.
+</Callout>
+
+The reverse trap is worse than a slow sync endpoint. Write `async def` and then block inside it, and you don't just slow down that one request:
+
+```python {6} showLineNumbers
+from fastapi import FastAPI
+import time
+
+app = FastAPI()
+
+@app.get("/broken")
+async def call_service_broken():
+    time.sleep(5)  # blocks the entire event loop for 5 seconds
+    return {"status": "ok"}
+```
+
+While this coroutine sleeps, every other request assigned to that worker's event loop, including your health check, hangs right along with it.
+
+<Callout icon="⚡" type="danger">
+If you write <code>async def</code>, everything inside it must be awaitable, or fast enough that it doesn't matter. If you can't guarantee that, plain <code>def</code> is not a downgrade, it's the correct choice, and FastAPI will thread it for you automatically. This exact rule is the first thing [zhanymkanov's fastapi-best-practices](https://github.com/zhanymkanov/fastapi-best-practices) guide covers, for good reason.
+</Callout>
+
+## So, who wins? How to actually decide
+
+1. **Is the task CPU-bound?** Parsing huge files, running ML inference, crunching numbers in pure Python. Then neither threading nor asyncio helps: async gives you zero parallelism because it's one thread, and threading gives you zero parallelism because of the GIL. This is `multiprocessing` / `ProcessPoolExecutor` territory, or, inside a FastAPI app, offloading to a background worker queue like Celery or arq. Full detail on that path lives in [the GIL post](/blog/we-need-to-talk-about-gil).
+2. **I/O-bound, with async-native libraries available end to end?** Asyncio wins, especially at high fan-out: many simultaneous slow calls, websockets, thousands of open connections.
+3. **I/O-bound, but stuck with a blocking library** (a legacy SDK, an ORM with no async driver)? Threading wins here: a plain `def` endpoint in FastAPI, a `ThreadPoolExecutor`, or, if you're already inside async code and just need to call one blocking function, `await asyncio.to_thread(blocking_fn)` is the official escape hatch.
+4. **Modest concurrency and simple code?** Plain synchronous code is genuinely fine. Don't pay async's cognitive tax for a service handling ten requests a second.
+
+<Callout icon="⚡" type="warning">
+The one-line takeaway of this entire post: <code>async</code> does not make your code faster. It makes waiting cheaper. If your code isn't waiting on anything, async has nothing to offer you, and the GIL makes sure threading doesn't either.
+</Callout>
+
+## Conclusion
+
+There's no real "supremacy" here, the battle framing was always a bit of a trick. Threading and asyncio solve the exact same problem, idle time spent waiting, with opposite trade-offs: threads buy you compatibility with the code you already have at the cost of scale and the need for locks; asyncio buys you scale at the cost of rewriting your dependencies and a sharper failure mode when something blocks by accident. FastAPI's actual genius isn't "async is faster", it's letting you choose the right tool per endpoint instead of forcing one model on your whole application.
+
+Pick based on what your task is actually doing, not on what's fashionable to type. And keep an eye on free-threaded Python (PEP 703, now shipping as an experimental build) — it's already starting to shift these trade-offs again, which might just be the topic for post number three.
+
+### Further Reading
+- [FastAPI Best Practices — zhanymkanov](https://github.com/zhanymkanov/fastapi-best-practices)
+- [asyncio — Asynchronous I/O (Python docs)](https://docs.python.org/3/library/asyncio.html)
+- [threading — Thread-based parallelism (Python docs)](https://docs.python.org/3/library/threading.html)
+- [concurrent.futures — Launching parallel tasks (Python docs)](https://docs.python.org/3/library/concurrent.futures.html)
+- [FastAPI docs — Concurrency and async / await](https://fastapi.tiangolo.com/async/)
+- [We need to talk about GIL!](/blog/we-need-to-talk-about-gil)
+
+As always: profile first, then pick the tool, the fastest concurrency model is the one that actually matches what your code is waiting for.

--- a/content/async-vs-threading-the-battle-for-supremacy.mdx
+++ b/content/async-vs-threading-the-battle-for-supremacy.mdx
@@ -245,6 +245,22 @@ While this coroutine sleeps, every other request assigned to that worker's event
 If you write <code>async def</code>, everything inside it must be awaitable, or fast enough that it doesn't matter. If you can't guarantee that, plain <code>def</code> is not a downgrade, it's the correct choice, and FastAPI will thread it for you automatically. This exact rule is the first thing [zhanymkanov's fastapi-best-practices](https://github.com/zhanymkanov/fastapi-best-practices) guide covers, for good reason.
 </Callout>
 
+### Whose event loop is it, anyway?
+
+Here's a question I got asked more than once, and it's a fair one: FastAPI is a framework, so where does the actual event loop come from? FastAPI itself doesn't run one. It's an ASGI application, a callable that describes how to handle a request, nothing more. The event loop is supplied by whatever ASGI server boots it, almost always **Uvicorn**. When Uvicorn starts, it creates one asyncio event loop per worker **process**, and by default it swaps the standard library's loop for **uvloop**, a drop-in implementation built on `libuv` (the same library behind Node.js) that's noticeably faster at the same job.
+
+This has a consequence worth naming explicitly: `--workers` and `async def` solve two completely different problems.
+
+```bash
+uvicorn app:app --workers 4
+```
+
+Four workers means four separate OS processes, each with its own interpreter, its own GIL, and its own event loop. That's real, process-level parallelism, the same kind `multiprocessing` gives you, and it's what actually lets a FastAPI deployment use more than one CPU core. Inside each of those processes, the single event loop is what gives you high *concurrency*: one core juggling thousands of parked requests, exactly as described earlier in this post, just now with a name and a process boundary attached to it. Every incoming request on a worker becomes a task scheduled onto that worker's loop; the loop doesn't know or care about the other three workers running right next to it.
+
+<Callout icon="💡" type="informative">
+Workers buy you parallelism across cores. Async buys you concurrency within a core. Tuning only one of the two, adding `async def` everywhere while running a single worker, or adding workers while every endpoint blocks the loop, is a common way FastAPI deployments end up slower than expected under load.
+</Callout>
+
 ## So, who wins? How to actually decide
 
 Here's the whole decision as a flow: three questions, four possible landings.

--- a/content/async-vs-threading-the-battle-for-supremacy.mdx
+++ b/content/async-vs-threading-the-battle-for-supremacy.mdx
@@ -247,6 +247,10 @@ If you write <code>async def</code>, everything inside it must be awaitable, or 
 
 ## So, who wins? How to actually decide
 
+Here's the whole decision as a flow: three questions, four possible landings.
+
+<img src="/blog/static/async-vs-threading-the-battle-for-supremacy/decision-flow.svg" alt="Decision flowchart: is the task CPU-bound leads to multiprocessing, otherwise stuck with blocking-only libraries leads to threading, otherwise needing high concurrency leads to asyncio, otherwise plain sync is fine" />
+
 1. **Is the task CPU-bound?** Parsing huge files, running ML inference, crunching numbers in pure Python. Then neither threading nor asyncio helps: async gives you zero parallelism because it's one thread, and threading gives you zero parallelism because of the GIL. This is `multiprocessing` / `ProcessPoolExecutor` territory, or, inside a FastAPI app, offloading to a background worker queue like Celery or arq. Full detail on that path lives in [the GIL post](/blog/we-need-to-talk-about-gil).
 2. **I/O-bound, with async-native libraries available end to end?** Asyncio wins, especially at high fan-out: many simultaneous slow calls, websockets, thousands of open connections.
 3. **I/O-bound, but stuck with a blocking library** (a legacy SDK, an ORM with no async driver)? Threading wins here: a plain `def` endpoint in FastAPI, a `ThreadPoolExecutor`, or, if you're already inside async code and just need to call one blocking function, `await asyncio.to_thread(blocking_fn)` is the official escape hatch.

--- a/public/static/async-vs-threading-the-battle-for-supremacy/decision-flow.svg
+++ b/public/static/async-vs-threading-the-battle-for-supremacy/decision-flow.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 760" width="880" height="760" role="img" aria-label="Decision flow: is the task CPU-bound leads to multiprocessing, otherwise stuck with blocking-only libraries leads to threading, otherwise needing high concurrency leads to asyncio, otherwise plain sync is fine">
-  <rect x="0" y="0" width="880" height="760" rx="12" fill="#f8fafc"/>
-  <text x="440" y="36" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="600" fill="#0f172a">Which one should I actually use?</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 740" width="880" height="740" role="img" aria-label="Decision flow: is the task CPU-bound leads to multiprocessing, otherwise stuck with blocking-only libraries leads to threading, otherwise needing high concurrency leads to asyncio, otherwise plain sync is fine">
+  <rect x="0" y="0" width="880" height="740" rx="12" fill="#f8fafc"/>
+  <text x="440" y="28" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="600" fill="#0f172a">Which one should I actually use?</text>
 
   <defs>
     <marker id="dfArrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
@@ -11,69 +11,69 @@
   <g font-family="ui-sans-serif, system-ui, sans-serif">
 
     <!-- Q1 -->
-    <polygon points="170,40 270,80 170,120 70,80" fill="#ffffff" stroke="#334155" stroke-width="2"/>
-    <text x="170" y="75" text-anchor="middle" font-size="13" font-weight="600" fill="#0f172a">Is the task</text>
-    <text x="170" y="91" text-anchor="middle" font-size="13" font-weight="600" fill="#0f172a">CPU-bound?</text>
+    <polygon points="170,60 270,100 170,140 70,100" fill="#ffffff" stroke="#334155" stroke-width="2"/>
+    <text x="170" y="95" text-anchor="middle" font-size="13" font-weight="600" fill="#0f172a">Is the task</text>
+    <text x="170" y="111" text-anchor="middle" font-size="13" font-weight="600" fill="#0f172a">CPU-bound?</text>
 
     <!-- Q1 -> Outcome1 (yes) -->
-    <line x1="270" y1="80" x2="496" y2="80" stroke="#16a34a" stroke-width="2" marker-end="url(#dfArrow)"/>
-    <text x="383" y="72" text-anchor="middle" font-size="12" font-weight="700" fill="#16a34a">yes</text>
+    <line x1="270" y1="100" x2="496" y2="100" stroke="#16a34a" stroke-width="2" marker-end="url(#dfArrow)"/>
+    <text x="383" y="92" text-anchor="middle" font-size="12" font-weight="700" fill="#16a34a">yes</text>
 
     <!-- Q1 -> Q2 (no) -->
-    <line x1="170" y1="120" x2="170" y2="246" stroke="#64748b" stroke-width="2" marker-end="url(#dfArrow)"/>
-    <text x="188" y="188" font-size="12" font-weight="700" fill="#64748b">no</text>
+    <line x1="170" y1="140" x2="170" y2="266" stroke="#64748b" stroke-width="2" marker-end="url(#dfArrow)"/>
+    <text x="188" y="208" font-size="12" font-weight="700" fill="#64748b">no</text>
 
     <!-- Q2 -->
-    <polygon points="170,250 270,290 170,330 70,290" fill="#ffffff" stroke="#334155" stroke-width="2"/>
-    <text x="170" y="280" text-anchor="middle" font-size="12.5" font-weight="600" fill="#0f172a">Stuck with blocking-only</text>
-    <text x="170" y="296" text-anchor="middle" font-size="12.5" font-weight="600" fill="#0f172a">libraries (no async driver)?</text>
+    <polygon points="170,270 270,310 170,350 70,310" fill="#ffffff" stroke="#334155" stroke-width="2"/>
+    <text x="170" y="300" text-anchor="middle" font-size="12.5" font-weight="600" fill="#0f172a">Stuck with blocking-only</text>
+    <text x="170" y="316" text-anchor="middle" font-size="12.5" font-weight="600" fill="#0f172a">libraries (no async driver)?</text>
 
     <!-- Q2 -> Outcome2 (yes) -->
-    <line x1="270" y1="290" x2="496" y2="290" stroke="#16a34a" stroke-width="2" marker-end="url(#dfArrow)"/>
-    <text x="383" y="282" text-anchor="middle" font-size="12" font-weight="700" fill="#16a34a">yes</text>
+    <line x1="270" y1="310" x2="496" y2="310" stroke="#16a34a" stroke-width="2" marker-end="url(#dfArrow)"/>
+    <text x="383" y="302" text-anchor="middle" font-size="12" font-weight="700" fill="#16a34a">yes</text>
 
     <!-- Q2 -> Q3 (no) -->
-    <line x1="170" y1="330" x2="170" y2="456" stroke="#64748b" stroke-width="2" marker-end="url(#dfArrow)"/>
-    <text x="188" y="398" font-size="12" font-weight="700" fill="#64748b">no</text>
+    <line x1="170" y1="350" x2="170" y2="476" stroke="#64748b" stroke-width="2" marker-end="url(#dfArrow)"/>
+    <text x="188" y="418" font-size="12" font-weight="700" fill="#64748b">no</text>
 
     <!-- Q3 -->
-    <polygon points="170,460 270,500 170,540 70,500" fill="#ffffff" stroke="#334155" stroke-width="2"/>
-    <text x="170" y="490" text-anchor="middle" font-size="12.5" font-weight="600" fill="#0f172a">Need high concurrency</text>
-    <text x="170" y="506" text-anchor="middle" font-size="12.5" font-weight="600" fill="#0f172a">(many I/O calls at once)?</text>
+    <polygon points="170,480 270,520 170,560 70,520" fill="#ffffff" stroke="#334155" stroke-width="2"/>
+    <text x="170" y="510" text-anchor="middle" font-size="12.5" font-weight="600" fill="#0f172a">Need high concurrency</text>
+    <text x="170" y="526" text-anchor="middle" font-size="12.5" font-weight="600" fill="#0f172a">(many I/O calls at once)?</text>
 
     <!-- Q3 -> Outcome3 (yes) -->
-    <line x1="270" y1="500" x2="496" y2="500" stroke="#16a34a" stroke-width="2" marker-end="url(#dfArrow)"/>
-    <text x="383" y="492" text-anchor="middle" font-size="12" font-weight="700" fill="#16a34a">yes</text>
+    <line x1="270" y1="520" x2="496" y2="520" stroke="#16a34a" stroke-width="2" marker-end="url(#dfArrow)"/>
+    <text x="383" y="512" text-anchor="middle" font-size="12" font-weight="700" fill="#16a34a">yes</text>
 
     <!-- Q3 -> Outcome4 (no) -->
-    <line x1="170" y1="540" x2="170" y2="596" stroke="#64748b" stroke-width="2" marker-end="url(#dfArrow)"/>
-    <text x="188" y="572" font-size="12" font-weight="700" fill="#64748b">no</text>
+    <line x1="170" y1="560" x2="170" y2="616" stroke="#64748b" stroke-width="2" marker-end="url(#dfArrow)"/>
+    <text x="188" y="592" font-size="12" font-weight="700" fill="#64748b">no</text>
 
     <!-- Outcome 1: multiprocessing (red, mirrors Callout danger) -->
-    <rect x="500" y="25" width="340" height="110" rx="8" fill="#fef2f2" stroke="#7f1d1d" stroke-width="2"/>
-    <text x="516" y="52" font-size="15" font-weight="700" fill="#7f1d1d">Neither helps</text>
-    <text x="516" y="74" font-size="12.5" fill="#334155">Use <tspan font-weight="600">multiprocessing</tspan> /</text>
-    <text x="516" y="92" font-size="12.5" fill="#334155"><tspan font-weight="600">ProcessPoolExecutor</tspan>, or offload to</text>
-    <text x="516" y="110" font-size="12.5" fill="#334155">a worker queue (Celery, arq).</text>
+    <rect x="500" y="45" width="340" height="110" rx="8" fill="#fef2f2" stroke="#7f1d1d" stroke-width="2"/>
+    <text x="516" y="72" font-size="15" font-weight="700" fill="#7f1d1d">Neither helps</text>
+    <text x="516" y="94" font-size="12.5" fill="#334155">Use <tspan font-weight="600">multiprocessing</tspan> /</text>
+    <text x="516" y="112" font-size="12.5" fill="#334155"><tspan font-weight="600">ProcessPoolExecutor</tspan>, or offload to</text>
+    <text x="516" y="130" font-size="12.5" fill="#334155">a worker queue (Celery, arq).</text>
 
     <!-- Outcome 2: threading (neutral slate) -->
-    <rect x="500" y="235" width="340" height="110" rx="8" fill="#f1f5f9" stroke="#334155" stroke-width="2"/>
-    <text x="516" y="262" font-size="15" font-weight="700" fill="#0f172a">Threading wins</text>
-    <text x="516" y="284" font-size="12.5" fill="#334155">Plain <tspan font-weight="600">def</tspan> endpoints,</text>
-    <text x="516" y="302" font-size="12.5" fill="#334155"><tspan font-weight="600">ThreadPoolExecutor</tspan>, or</text>
-    <text x="516" y="320" font-size="12.5" fill="#334155"><tspan font-weight="600">asyncio.to_thread()</tspan> from async code.</text>
+    <rect x="500" y="255" width="340" height="110" rx="8" fill="#f1f5f9" stroke="#334155" stroke-width="2"/>
+    <text x="516" y="282" font-size="15" font-weight="700" fill="#0f172a">Threading wins</text>
+    <text x="516" y="304" font-size="12.5" fill="#334155">Plain <tspan font-weight="600">def</tspan> endpoints,</text>
+    <text x="516" y="322" font-size="12.5" fill="#334155"><tspan font-weight="600">ThreadPoolExecutor</tspan>, or</text>
+    <text x="516" y="340" font-size="12.5" fill="#334155"><tspan font-weight="600">asyncio.to_thread()</tspan> from async code.</text>
 
     <!-- Outcome 3: asyncio (green, mirrors Callout informative) -->
-    <rect x="500" y="445" width="340" height="110" rx="8" fill="#f0fdf4" stroke="#14532d" stroke-width="2"/>
-    <text x="516" y="472" font-size="15" font-weight="700" fill="#14532d">Asyncio wins</text>
-    <text x="516" y="494" font-size="12.5" fill="#334155">Async-native libraries end to end,</text>
-    <text x="516" y="512" font-size="12.5" fill="#334155">tasks are cheap enough to scale to</text>
-    <text x="516" y="530" font-size="12.5" fill="#334155">thousands of open connections.</text>
+    <rect x="500" y="465" width="340" height="110" rx="8" fill="#f0fdf4" stroke="#14532d" stroke-width="2"/>
+    <text x="516" y="492" font-size="15" font-weight="700" fill="#14532d">Asyncio wins</text>
+    <text x="516" y="514" font-size="12.5" fill="#334155">Async-native libraries end to end,</text>
+    <text x="516" y="532" font-size="12.5" fill="#334155">tasks are cheap enough to scale to</text>
+    <text x="516" y="550" font-size="12.5" fill="#334155">thousands of open connections.</text>
 
     <!-- Outcome 4: plain sync (gray, terminal "no") -->
-    <rect x="20" y="600" width="300" height="100" rx="8" fill="#f8fafc" stroke="#475569" stroke-width="2"/>
-    <text x="36" y="627" font-size="15" font-weight="700" fill="#334155">Plain sync is fine</text>
-    <text x="36" y="649" font-size="12.5" fill="#334155">Modest concurrency, simple code,</text>
-    <text x="36" y="667" font-size="12.5" fill="#334155">don't pay async's cognitive tax.</text>
+    <rect x="20" y="620" width="300" height="100" rx="8" fill="#f8fafc" stroke="#475569" stroke-width="2"/>
+    <text x="36" y="647" font-size="15" font-weight="700" fill="#334155">Plain sync is fine</text>
+    <text x="36" y="669" font-size="12.5" fill="#334155">Modest concurrency, simple code,</text>
+    <text x="36" y="687" font-size="12.5" fill="#334155">don't pay async's cognitive tax.</text>
   </g>
 </svg>

--- a/public/static/async-vs-threading-the-battle-for-supremacy/decision-flow.svg
+++ b/public/static/async-vs-threading-the-battle-for-supremacy/decision-flow.svg
@@ -11,43 +11,43 @@
   <g font-family="ui-sans-serif, system-ui, sans-serif">
 
     <!-- Q1 -->
-    <polygon points="170,60 270,100 170,140 70,100" fill="#ffffff" stroke="#334155" stroke-width="2"/>
+    <polygon points="170,55 320,100 170,145 20,100" fill="#ffffff" stroke="#334155" stroke-width="2"/>
     <text x="170" y="95" text-anchor="middle" font-size="13" font-weight="600" fill="#0f172a">Is the task</text>
     <text x="170" y="111" text-anchor="middle" font-size="13" font-weight="600" fill="#0f172a">CPU-bound?</text>
 
     <!-- Q1 -> Outcome1 (yes) -->
-    <line x1="270" y1="100" x2="496" y2="100" stroke="#16a34a" stroke-width="2" marker-end="url(#dfArrow)"/>
-    <text x="383" y="92" text-anchor="middle" font-size="12" font-weight="700" fill="#16a34a">yes</text>
+    <line x1="320" y1="100" x2="496" y2="100" stroke="#16a34a" stroke-width="2" marker-end="url(#dfArrow)"/>
+    <text x="408" y="92" text-anchor="middle" font-size="12" font-weight="700" fill="#16a34a">yes</text>
 
     <!-- Q1 -> Q2 (no) -->
-    <line x1="170" y1="140" x2="170" y2="266" stroke="#64748b" stroke-width="2" marker-end="url(#dfArrow)"/>
-    <text x="188" y="208" font-size="12" font-weight="700" fill="#64748b">no</text>
+    <line x1="170" y1="145" x2="170" y2="261" stroke="#64748b" stroke-width="2" marker-end="url(#dfArrow)"/>
+    <text x="188" y="207" font-size="12" font-weight="700" fill="#64748b">no</text>
 
     <!-- Q2 -->
-    <polygon points="170,270 270,310 170,350 70,310" fill="#ffffff" stroke="#334155" stroke-width="2"/>
+    <polygon points="170,265 320,310 170,355 20,310" fill="#ffffff" stroke="#334155" stroke-width="2"/>
     <text x="170" y="300" text-anchor="middle" font-size="12.5" font-weight="600" fill="#0f172a">Stuck with blocking-only</text>
     <text x="170" y="316" text-anchor="middle" font-size="12.5" font-weight="600" fill="#0f172a">libraries (no async driver)?</text>
 
     <!-- Q2 -> Outcome2 (yes) -->
-    <line x1="270" y1="310" x2="496" y2="310" stroke="#16a34a" stroke-width="2" marker-end="url(#dfArrow)"/>
-    <text x="383" y="302" text-anchor="middle" font-size="12" font-weight="700" fill="#16a34a">yes</text>
+    <line x1="320" y1="310" x2="496" y2="310" stroke="#16a34a" stroke-width="2" marker-end="url(#dfArrow)"/>
+    <text x="408" y="302" text-anchor="middle" font-size="12" font-weight="700" fill="#16a34a">yes</text>
 
     <!-- Q2 -> Q3 (no) -->
-    <line x1="170" y1="350" x2="170" y2="476" stroke="#64748b" stroke-width="2" marker-end="url(#dfArrow)"/>
-    <text x="188" y="418" font-size="12" font-weight="700" fill="#64748b">no</text>
+    <line x1="170" y1="355" x2="170" y2="471" stroke="#64748b" stroke-width="2" marker-end="url(#dfArrow)"/>
+    <text x="188" y="417" font-size="12" font-weight="700" fill="#64748b">no</text>
 
     <!-- Q3 -->
-    <polygon points="170,480 270,520 170,560 70,520" fill="#ffffff" stroke="#334155" stroke-width="2"/>
+    <polygon points="170,475 320,520 170,565 20,520" fill="#ffffff" stroke="#334155" stroke-width="2"/>
     <text x="170" y="510" text-anchor="middle" font-size="12.5" font-weight="600" fill="#0f172a">Need high concurrency</text>
     <text x="170" y="526" text-anchor="middle" font-size="12.5" font-weight="600" fill="#0f172a">(many I/O calls at once)?</text>
 
     <!-- Q3 -> Outcome3 (yes) -->
-    <line x1="270" y1="520" x2="496" y2="520" stroke="#16a34a" stroke-width="2" marker-end="url(#dfArrow)"/>
-    <text x="383" y="512" text-anchor="middle" font-size="12" font-weight="700" fill="#16a34a">yes</text>
+    <line x1="320" y1="520" x2="496" y2="520" stroke="#16a34a" stroke-width="2" marker-end="url(#dfArrow)"/>
+    <text x="408" y="512" text-anchor="middle" font-size="12" font-weight="700" fill="#16a34a">yes</text>
 
     <!-- Q3 -> Outcome4 (no) -->
-    <line x1="170" y1="560" x2="170" y2="616" stroke="#64748b" stroke-width="2" marker-end="url(#dfArrow)"/>
-    <text x="188" y="592" font-size="12" font-weight="700" fill="#64748b">no</text>
+    <line x1="170" y1="565" x2="170" y2="616" stroke="#64748b" stroke-width="2" marker-end="url(#dfArrow)"/>
+    <text x="188" y="596" font-size="12" font-weight="700" fill="#64748b">no</text>
 
     <!-- Outcome 1: multiprocessing (red, mirrors Callout danger) -->
     <rect x="500" y="45" width="340" height="110" rx="8" fill="#fef2f2" stroke="#7f1d1d" stroke-width="2"/>

--- a/public/static/async-vs-threading-the-battle-for-supremacy/decision-flow.svg
+++ b/public/static/async-vs-threading-the-battle-for-supremacy/decision-flow.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 760" width="880" height="760" role="img" aria-label="Decision flow: is the task CPU-bound leads to multiprocessing, otherwise stuck with blocking-only libraries leads to threading, otherwise needing high concurrency leads to asyncio, otherwise plain sync is fine">
+  <rect x="0" y="0" width="880" height="760" rx="12" fill="#f8fafc"/>
+  <text x="440" y="36" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="600" fill="#0f172a">Which one should I actually use?</text>
+
+  <defs>
+    <marker id="dfArrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#334155"/>
+    </marker>
+  </defs>
+
+  <g font-family="ui-sans-serif, system-ui, sans-serif">
+
+    <!-- Q1 -->
+    <polygon points="170,40 270,80 170,120 70,80" fill="#ffffff" stroke="#334155" stroke-width="2"/>
+    <text x="170" y="75" text-anchor="middle" font-size="13" font-weight="600" fill="#0f172a">Is the task</text>
+    <text x="170" y="91" text-anchor="middle" font-size="13" font-weight="600" fill="#0f172a">CPU-bound?</text>
+
+    <!-- Q1 -> Outcome1 (yes) -->
+    <line x1="270" y1="80" x2="496" y2="80" stroke="#16a34a" stroke-width="2" marker-end="url(#dfArrow)"/>
+    <text x="383" y="72" text-anchor="middle" font-size="12" font-weight="700" fill="#16a34a">yes</text>
+
+    <!-- Q1 -> Q2 (no) -->
+    <line x1="170" y1="120" x2="170" y2="246" stroke="#64748b" stroke-width="2" marker-end="url(#dfArrow)"/>
+    <text x="188" y="188" font-size="12" font-weight="700" fill="#64748b">no</text>
+
+    <!-- Q2 -->
+    <polygon points="170,250 270,290 170,330 70,290" fill="#ffffff" stroke="#334155" stroke-width="2"/>
+    <text x="170" y="280" text-anchor="middle" font-size="12.5" font-weight="600" fill="#0f172a">Stuck with blocking-only</text>
+    <text x="170" y="296" text-anchor="middle" font-size="12.5" font-weight="600" fill="#0f172a">libraries (no async driver)?</text>
+
+    <!-- Q2 -> Outcome2 (yes) -->
+    <line x1="270" y1="290" x2="496" y2="290" stroke="#16a34a" stroke-width="2" marker-end="url(#dfArrow)"/>
+    <text x="383" y="282" text-anchor="middle" font-size="12" font-weight="700" fill="#16a34a">yes</text>
+
+    <!-- Q2 -> Q3 (no) -->
+    <line x1="170" y1="330" x2="170" y2="456" stroke="#64748b" stroke-width="2" marker-end="url(#dfArrow)"/>
+    <text x="188" y="398" font-size="12" font-weight="700" fill="#64748b">no</text>
+
+    <!-- Q3 -->
+    <polygon points="170,460 270,500 170,540 70,500" fill="#ffffff" stroke="#334155" stroke-width="2"/>
+    <text x="170" y="490" text-anchor="middle" font-size="12.5" font-weight="600" fill="#0f172a">Need high concurrency</text>
+    <text x="170" y="506" text-anchor="middle" font-size="12.5" font-weight="600" fill="#0f172a">(many I/O calls at once)?</text>
+
+    <!-- Q3 -> Outcome3 (yes) -->
+    <line x1="270" y1="500" x2="496" y2="500" stroke="#16a34a" stroke-width="2" marker-end="url(#dfArrow)"/>
+    <text x="383" y="492" text-anchor="middle" font-size="12" font-weight="700" fill="#16a34a">yes</text>
+
+    <!-- Q3 -> Outcome4 (no) -->
+    <line x1="170" y1="540" x2="170" y2="596" stroke="#64748b" stroke-width="2" marker-end="url(#dfArrow)"/>
+    <text x="188" y="572" font-size="12" font-weight="700" fill="#64748b">no</text>
+
+    <!-- Outcome 1: multiprocessing (red, mirrors Callout danger) -->
+    <rect x="500" y="25" width="340" height="110" rx="8" fill="#fef2f2" stroke="#7f1d1d" stroke-width="2"/>
+    <text x="516" y="52" font-size="15" font-weight="700" fill="#7f1d1d">Neither helps</text>
+    <text x="516" y="74" font-size="12.5" fill="#334155">Use <tspan font-weight="600">multiprocessing</tspan> /</text>
+    <text x="516" y="92" font-size="12.5" fill="#334155"><tspan font-weight="600">ProcessPoolExecutor</tspan>, or offload to</text>
+    <text x="516" y="110" font-size="12.5" fill="#334155">a worker queue (Celery, arq).</text>
+
+    <!-- Outcome 2: threading (neutral slate) -->
+    <rect x="500" y="235" width="340" height="110" rx="8" fill="#f1f5f9" stroke="#334155" stroke-width="2"/>
+    <text x="516" y="262" font-size="15" font-weight="700" fill="#0f172a">Threading wins</text>
+    <text x="516" y="284" font-size="12.5" fill="#334155">Plain <tspan font-weight="600">def</tspan> endpoints,</text>
+    <text x="516" y="302" font-size="12.5" fill="#334155"><tspan font-weight="600">ThreadPoolExecutor</tspan>, or</text>
+    <text x="516" y="320" font-size="12.5" fill="#334155"><tspan font-weight="600">asyncio.to_thread()</tspan> from async code.</text>
+
+    <!-- Outcome 3: asyncio (green, mirrors Callout informative) -->
+    <rect x="500" y="445" width="340" height="110" rx="8" fill="#f0fdf4" stroke="#14532d" stroke-width="2"/>
+    <text x="516" y="472" font-size="15" font-weight="700" fill="#14532d">Asyncio wins</text>
+    <text x="516" y="494" font-size="12.5" fill="#334155">Async-native libraries end to end,</text>
+    <text x="516" y="512" font-size="12.5" fill="#334155">tasks are cheap enough to scale to</text>
+    <text x="516" y="530" font-size="12.5" fill="#334155">thousands of open connections.</text>
+
+    <!-- Outcome 4: plain sync (gray, terminal "no") -->
+    <rect x="20" y="600" width="300" height="100" rx="8" fill="#f8fafc" stroke="#475569" stroke-width="2"/>
+    <text x="36" y="627" font-size="15" font-weight="700" fill="#334155">Plain sync is fine</text>
+    <text x="36" y="649" font-size="12.5" fill="#334155">Modest concurrency, simple code,</text>
+    <text x="36" y="667" font-size="12.5" fill="#334155">don't pay async's cognitive tax.</text>
+  </g>
+</svg>

--- a/public/static/async-vs-threading-the-battle-for-supremacy/request-timeline.svg
+++ b/public/static/async-vs-threading-the-battle-for-supremacy/request-timeline.svg
@@ -15,6 +15,6 @@
     <text x="400" y="175" text-anchor="middle" font-size="14" fill="#0f172a">waiting on network / DB / disk</text>
     <text x="710" y="175" text-anchor="middle" font-size="14" fill="#0f172a">CPU</text>
 
-    <text x="400" y="205" text-anchor="middle" font-size="13" fill="#475569">Concurrency isn't about doing more work — it's about not standing still while you wait.</text>
+    <text x="400" y="205" text-anchor="middle" font-size="13" fill="#475569">Concurrency isn't about doing more work, it's about not standing still while you wait.</text>
   </g>
 </svg>

--- a/public/static/async-vs-threading-the-battle-for-supremacy/request-timeline.svg
+++ b/public/static/async-vs-threading-the-battle-for-supremacy/request-timeline.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 220" width="800" height="220" role="img" aria-label="Timeline of a single request showing a short CPU burst, a long wait on network or database, and a final short CPU burst">
+  <rect x="0" y="0" width="800" height="220" rx="12" fill="#f8fafc"/>
+  <text x="400" y="36" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="600" fill="#0f172a">Your server, most of the time</text>
+
+  <!-- timeline bar -->
+  <g font-family="ui-sans-serif, system-ui, sans-serif">
+    <rect x="60" y="90" width="60" height="60" fill="#16a34a"/>
+    <rect x="120" y="90" width="560" height="60" fill="#94a3b8"/>
+    <rect x="680" y="90" width="60" height="60" fill="#16a34a"/>
+    <rect x="60" y="90" width="680" height="60" fill="none" stroke="#334155" stroke-width="2"/>
+    <line x1="120" y1="90" x2="120" y2="150" stroke="#334155" stroke-width="2"/>
+    <line x1="680" y1="90" x2="680" y2="150" stroke="#334155" stroke-width="2"/>
+
+    <text x="90" y="175" text-anchor="middle" font-size="14" fill="#0f172a">CPU</text>
+    <text x="400" y="175" text-anchor="middle" font-size="14" fill="#0f172a">waiting on network / DB / disk</text>
+    <text x="710" y="175" text-anchor="middle" font-size="14" fill="#0f172a">CPU</text>
+
+    <text x="400" y="205" text-anchor="middle" font-size="13" fill="#475569">Concurrency isn't about doing more work — it's about not standing still while you wait.</text>
+  </g>
+</svg>

--- a/public/static/async-vs-threading-the-battle-for-supremacy/threads-vs-event-loop.svg
+++ b/public/static/async-vs-threading-the-battle-for-supremacy/threads-vs-event-loop.svg
@@ -11,7 +11,7 @@
   <line x1="500" y1="20" x2="500" y2="440" stroke="#cbd5e1" stroke-width="2" stroke-dasharray="6,6"/>
 
   <!-- LEFT: Threading -->
-  <text x="250" y="40" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="600" fill="#0f172a">Threading — preemptive</text>
+  <text x="250" y="40" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="600" fill="#0f172a">Threading, preemptive</text>
 
   <g font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#0f172a">
     <!-- lane labels -->
@@ -48,7 +48,7 @@
     <text x="155" y="75" text-anchor="middle" font-size="11" font-weight="700" fill="#0f172a">GIL</text>
   </g>
 
-  <text x="285" y="315" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#475569">Only one lane can run Python at a time — the rest wait their turn.</text>
+  <text x="285" y="315" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#475569">Only one lane can run Python at a time, the rest wait their turn.</text>
   <g font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" fill="#334155">
     <rect x="120" y="345" width="14" height="14" fill="#16a34a"/>
     <text x="140" y="356">running</text>
@@ -57,7 +57,7 @@
   </g>
 
   <!-- RIGHT: Asyncio -->
-  <text x="750" y="40" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="600" fill="#0f172a">Asyncio — cooperative</text>
+  <text x="750" y="40" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="600" fill="#0f172a">Asyncio, cooperative</text>
 
   <g>
     <!-- event loop circle with circular arrow -->
@@ -84,7 +84,7 @@
     <text x="640" y="222" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#475569">await</text>
   </g>
 
-  <text x="750" y="315" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#475569">One task runs until it yields — everyone else waits their turn, in order.</text>
+  <text x="750" y="315" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#475569">One task runs until it yields, everyone else waits their turn, in order.</text>
   <g font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" fill="#334155">
     <rect x="620" y="345" width="14" height="14" fill="#16a34a"/>
     <text x="640" y="356">running</text>

--- a/public/static/async-vs-threading-the-battle-for-supremacy/threads-vs-event-loop.svg
+++ b/public/static/async-vs-threading-the-battle-for-supremacy/threads-vs-event-loop.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 460" width="1000" height="460" role="img" aria-label="Side by side comparison: threading shows three OS thread lanes taking turns holding the GIL while asyncio shows a single event loop handing off between parked tasks at await points">
+  <rect x="0" y="0" width="1000" height="460" rx="12" fill="#f8fafc"/>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#334155"/>
+    </marker>
+  </defs>
+
+  <!-- divider -->
+  <line x1="500" y1="20" x2="500" y2="440" stroke="#cbd5e1" stroke-width="2" stroke-dasharray="6,6"/>
+
+  <!-- LEFT: Threading -->
+  <text x="250" y="40" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="600" fill="#0f172a">Threading — preemptive</text>
+
+  <g font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#0f172a">
+    <!-- lane labels -->
+    <text x="45" y="105">Thread 1</text>
+    <text x="45" y="185">Thread 2</text>
+    <text x="45" y="265">Thread 3</text>
+
+    <!-- lane 1: run / blocked / run -->
+    <rect x="120" y="85" width="70" height="30" fill="#16a34a"/>
+    <rect x="190" y="85" width="160" height="30" fill="#94a3b8"/>
+    <rect x="350" y="85" width="100" height="30" fill="#16a34a"/>
+
+    <!-- lane 2: blocked / run / blocked -->
+    <rect x="120" y="165" width="90" height="30" fill="#94a3b8"/>
+    <rect x="210" y="165" width="90" height="30" fill="#16a34a"/>
+    <rect x="300" y="165" width="150" height="30" fill="#94a3b8"/>
+
+    <!-- lane 3: run / blocked / run -->
+    <rect x="120" y="245" width="50" height="30" fill="#16a34a"/>
+    <rect x="170" y="245" width="210" height="30" fill="#94a3b8"/>
+    <rect x="380" y="245" width="70" height="30" fill="#16a34a"/>
+
+    <!-- lane borders -->
+    <rect x="120" y="85" width="330" height="30" fill="none" stroke="#334155" stroke-width="1.5"/>
+    <rect x="120" y="165" width="330" height="30" fill="none" stroke="#334155" stroke-width="1.5"/>
+    <rect x="120" y="245" width="330" height="30" fill="none" stroke="#334155" stroke-width="1.5"/>
+  </g>
+
+  <!-- GIL token hopping between the three "run" segments -->
+  <g font-family="ui-sans-serif, system-ui, sans-serif">
+    <path d="M155,85 C 200,60 220,140 255,165" fill="none" stroke="#334155" stroke-width="1.5" stroke-dasharray="4,4" marker-end="url(#arrow)"/>
+    <path d="M255,195 C 260,220 320,225 335,245" fill="none" stroke="#334155" stroke-width="1.5" stroke-dasharray="4,4" marker-end="url(#arrow)"/>
+    <circle cx="155" cy="70" r="16" fill="#fbbf24" stroke="#334155" stroke-width="1.5"/>
+    <text x="155" y="75" text-anchor="middle" font-size="11" font-weight="700" fill="#0f172a">GIL</text>
+  </g>
+
+  <text x="285" y="315" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#475569">Only one lane can run Python at a time — the rest wait their turn.</text>
+  <g font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" fill="#334155">
+    <rect x="120" y="345" width="14" height="14" fill="#16a34a"/>
+    <text x="140" y="356">running</text>
+    <rect x="230" y="345" width="14" height="14" fill="#94a3b8"/>
+    <text x="250" y="356">blocked on I/O (GIL released)</text>
+  </g>
+
+  <!-- RIGHT: Asyncio -->
+  <text x="750" y="40" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="600" fill="#0f172a">Asyncio — cooperative</text>
+
+  <g>
+    <!-- event loop circle with circular arrow -->
+    <circle cx="750" cy="200" r="55" fill="none" stroke="#334155" stroke-width="2"/>
+    <path d="M 750 145 A 55 55 0 1 1 700 178" fill="none" stroke="#334155" stroke-width="2.5" marker-end="url(#arrow)"/>
+    <text x="750" y="205" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="600" fill="#0f172a">event</text>
+    <text x="750" y="222" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="600" fill="#0f172a">loop</text>
+
+    <!-- task A: running -->
+    <rect x="715" y="70" width="70" height="34" rx="6" fill="#16a34a" stroke="#334155" stroke-width="1.5"/>
+    <text x="750" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="700" fill="#f8fafc">A</text>
+    <line x1="750" y1="104" x2="750" y2="145" stroke="#334155" stroke-width="1.5" stroke-dasharray="4,4"/>
+
+    <!-- task B: parked at await -->
+    <rect x="855" y="235" width="70" height="34" rx="6" fill="#94a3b8" stroke="#334155" stroke-width="1.5"/>
+    <text x="890" y="257" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="700" fill="#f8fafc">B</text>
+    <line x1="855" y1="245" x2="795" y2="220" stroke="#334155" stroke-width="1.5" stroke-dasharray="4,4"/>
+    <text x="880" y="222" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#475569">await</text>
+
+    <!-- task C: parked at await -->
+    <rect x="645" y="235" width="70" height="34" rx="6" fill="#94a3b8" stroke="#334155" stroke-width="1.5"/>
+    <text x="680" y="257" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="700" fill="#f8fafc">C</text>
+    <line x1="700" y1="245" x2="713" y2="222" stroke="#334155" stroke-width="1.5" stroke-dasharray="4,4"/>
+    <text x="640" y="222" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#475569">await</text>
+  </g>
+
+  <text x="750" y="315" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#475569">One task runs until it yields — everyone else waits their turn, in order.</text>
+  <g font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" fill="#334155">
+    <rect x="620" y="345" width="14" height="14" fill="#16a34a"/>
+    <text x="640" y="356">running</text>
+    <rect x="730" y="345" width="14" height="14" fill="#94a3b8"/>
+    <text x="750" y="356">parked, waiting to resume</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- New MDX post `content/async-vs-threading-the-battle-for-supremacy.mdx`: a follow-up to "We need to talk about GIL!" covering threading vs. asyncio, FastAPI's sync/async endpoint split, and a decision framework for when neither helps (CPU-bound work)
- Two hand-authored SVG diagrams (`public/static/async-vs-threading-the-battle-for-supremacy/`): a request-timeline illustration and a threads-vs-event-loop schematic
- Includes a threading-vs-asyncio comparison table, code examples (blocking, ThreadPoolExecutor, asyncio/httpx, FastAPI sync/async endpoints), and references to zhanymkanov's fastapi-best-practices repo + Python stdlib docs

Closes #29

## Test plan
- [x] `npx velite build` — frontmatter/MDX validates
- [x] `npx next build` — new route statically generated (`/async-vs-threading-the-battle-for-supremacy`)
- [x] Verified in dev server (dark mode): headings/anchors, both callout variants, code highlighting, both SVGs render legibly, internal link to `/blog/we-need-to-talk-about-gil` resolves
- [x] Found and fixed a real hydration bug: raw `<table>` needed explicit `<thead>`/`<tbody>` (browser auto-inserts them, causing an SSR/client DOM mismatch without them) — confirmed console is clean after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)