### PR TITLE
Add previous/next post navigation to post footer

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -4,8 +4,9 @@ import { notFound } from "next/navigation";
 import Image from "next/image";
 import { Tag } from "@/components/tag";
 import ScrollProgress from "@/components/scroll-progress";
+import { PostNavigation } from "@/components/post-navigation";
 import { Calendar, Clock } from "lucide-react";
-import { formatDate } from "@/lib/utils";
+import { formatDate, getAdjacentPosts } from "@/lib/utils";
 import readingDuration from 'reading-duration'
 import profilePicture from "@/public/static/profile.png";
 
@@ -52,7 +53,9 @@ export default async function PostPage({ params }: PostPageProps) {
     notFound();
   }
 
-  const readingTime = readingDuration(post.body, { 
+  const { previousPost, nextPost } = getAdjacentPosts(posts, post.slug);
+
+  const readingTime = readingDuration(post.body, {
     wordsPerMinute: 238, // Average silent reading rate for non-fiction
     emoji: false,
   })
@@ -88,6 +91,7 @@ export default async function PostPage({ params }: PostPageProps) {
       </div>
       <hr className="my-4" />
       <MdxComponent code={post.body} />
+      <PostNavigation previousPost={previousPost} nextPost={nextPost} />
     </article>
   );
 }

--- a/components/post-navigation.tsx
+++ b/components/post-navigation.tsx
@@ -1,0 +1,48 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import Link from "next/link";
+import { Post } from "#site/content";
+
+interface PostNavigationProps {
+  previousPost?: Pick<Post, "slug" | "title"> | null;
+  nextPost?: Pick<Post, "slug" | "title"> | null;
+}
+
+export function PostNavigation({ previousPost, nextPost }: PostNavigationProps) {
+  if (!previousPost && !nextPost) return null;
+
+  return (
+    <nav
+      aria-label="Post navigation"
+      className="not-prose mt-8 flex justify-between gap-4 border-t pt-6"
+    >
+      {previousPost ? (
+        <Link
+          href={"/" + previousPost.slug}
+          className="group flex max-w-[45%] flex-col gap-1 py-2"
+        >
+          <span className="flex items-center gap-1 text-sm text-muted-foreground">
+            <ChevronLeft className="h-4 w-4" /> Previous
+          </span>
+          <span className="line-clamp-2 font-medium group-hover:underline">
+            {previousPost.title}
+          </span>
+        </Link>
+      ) : (
+        <div />
+      )}
+      {nextPost ? (
+        <Link
+          href={"/" + nextPost.slug}
+          className="group ml-auto flex max-w-[45%] flex-col items-end gap-1 py-2 text-right"
+        >
+          <span className="flex items-center gap-1 text-sm text-muted-foreground">
+            Next <ChevronRight className="h-4 w-4" />
+          </span>
+          <span className="line-clamp-2 font-medium group-hover:underline">
+            {nextPost.title}
+          </span>
+        </Link>
+      ) : null}
+    </nav>
+  );
+}

--- a/e2e/post-navigation.spec.ts
+++ b/e2e/post-navigation.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+
+// Order (ascending by date) of currently published content. If a new post is
+// added, the oldest/newest assertions below may need updating — same
+// fragility class as the hard-coded "welcome" assertions elsewhere in this
+// suite.
+const OLDEST_POST = "welcome";
+const MIDDLE_POST = "we-need-to-talk-about-gil";
+const NEWEST_POST = "async-vs-threading-the-battle-for-supremacy";
+
+test.describe("Post navigation", () => {
+  test("middle post shows both previous and next links", async ({ page }) => {
+    await page.goto(MIDDLE_POST);
+    const nav = page.getByRole("navigation", { name: "Post navigation" });
+
+    await expect(nav).toBeVisible();
+    await expect(
+      nav.getByRole("link", { name: /Welcome to the Blog!/ })
+    ).toBeVisible();
+    await expect(
+      nav.getByRole("link", { name: /Containerization: A Chroot with Steroids/ })
+    ).toBeVisible();
+    await expect(nav.getByText("Previous")).toBeVisible();
+    await expect(nav.getByText("Next")).toBeVisible();
+  });
+
+  test("oldest post shows only a next link", async ({ page }) => {
+    await page.goto(OLDEST_POST);
+    const nav = page.getByRole("navigation", { name: "Post navigation" });
+
+    await expect(nav).toBeVisible();
+    await expect(nav.getByText("Next")).toBeVisible();
+    await expect(nav.getByText("Previous")).toHaveCount(0);
+  });
+
+  test("newest post shows only a previous link", async ({ page }) => {
+    await page.goto(NEWEST_POST);
+    const nav = page.getByRole("navigation", { name: "Post navigation" });
+
+    await expect(nav).toBeVisible();
+    await expect(nav.getByText("Previous")).toBeVisible();
+    await expect(nav.getByText("Next")).toHaveCount(0);
+  });
+
+  test("clicking the previous link navigates to the older post", async ({
+    page,
+  }) => {
+    await page.goto(MIDDLE_POST);
+    const nav = page.getByRole("navigation", { name: "Post navigation" });
+
+    await nav.getByRole("link", { name: /Welcome to the Blog!/ }).click();
+    await expect(page).toHaveURL(new RegExp(`/blog/${OLDEST_POST}$`));
+  });
+
+  test("clicking the next link navigates to the newer post", async ({
+    page,
+  }) => {
+    await page.goto(OLDEST_POST);
+    const nav = page.getByRole("navigation", { name: "Post navigation" });
+
+    await nav.getByRole("link", { name: /We need to talk about GIL!/ }).click();
+    await expect(page).toHaveURL(new RegExp(`/blog/${MIDDLE_POST}$`));
+  });
+});

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -24,6 +24,18 @@ export function sortPosts(posts: Array<Post>) {
   });
 }
 
+export function getAdjacentPosts(allPosts: Array<Post>, slug: string) {
+  const sorted = sortPosts(allPosts.filter((post) => post.published));
+  const index = sorted.findIndex((post) => post.slug === slug);
+
+  if (index === -1) return { previousPost: null, nextPost: null };
+
+  return {
+    nextPost: index > 0 ? sorted[index - 1] : null,
+    previousPost: index < sorted.length - 1 ? sorted[index + 1] : null,
+  };
+}
+
 export function getAllTags(posts: Array<Post>) {
   const tags: Record<string, number> = {}
   posts.forEach(post => {


### PR DESCRIPTION
## Summary
- Adds a "Previous"/"Next" post nav at the bottom of each post (older post on the left, newer on the right, chevron arrows + title), per issue #31.
- Adjacency is computed from `sortPosts()`/Velite post data, filtered to `published` posts only.
- New reusable `PostNavigation` component (`components/post-navigation.tsx`), wired into `app/[slug]/page.tsx` after the article body.

## Test plan
- [x] `npm run test:e2e` — new `e2e/post-navigation.spec.ts` covers: middle post shows both links, oldest post shows only "Next", newest post shows only "Previous", and clicking either link navigates to the correct adjacent post.
- [x] Full Playwright suite (136 tests, 134 passed / 2 pre-existing skips) — no regressions.
- [x] Manual visual check via screenshot — nav renders correctly above the global footer.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)