### PR TITLE
Replace italic-I logo with current mark

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,6 +1,6 @@
 import ChangeThemeButton from "@/components/change-theme-button";
+import Logo from "@/components/logo";
 import { Button } from "@/components/ui/button";
-import { ItalicIcon } from "lucide-react";
 import Link from "next/link";
 
 export default function Header(){
@@ -8,7 +8,7 @@ export default function Header(){
     <header className="py-6 lg:py-10">
       <div className="flex gap-4 flex-row justify-between md:gap-8">
         <Link className="hidden sm:inline-block" href="/">
-          <ItalicIcon size={36}/>
+          <Logo size={36}/>
         </Link>
         <nav className="my-auto text-xl">
           <ul className="flex flex-wrap sm:gap-16">

--- a/components/logo.tsx
+++ b/components/logo.tsx
@@ -1,0 +1,12 @@
+export default function Logo({ size = 36 }: { size?: number }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 375 375" width={size} height={size}>
+      <rect width="375" height="375" rx="17.25" fill="currentColor" />
+      <path
+        transform="translate(84.108568, 302.248811)"
+        fill="hsl(var(--background))"
+        d="M 180.921875 -238.8125 L 180.921875 -197.46875 L 131.640625 -197.46875 L 131.640625 -41.53125 L 180.921875 -41.53125 L 180.921875 0 L 25.84375 0 L 25.84375 -41.53125 L 75.125 -41.53125 L 75.125 -197.46875 L 25.84375 -197.46875 L 25.84375 -238.8125 Z"
+      />
+    </svg>
+  );
+}

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,1 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-italic"><line x1="19" x2="10" y1="4" y2="4"/><line x1="14" x2="5" y1="20" y2="20"/><line x1="15" x2="9" y1="4" y2="20"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 375 375" width="375" height="375">
+  <rect width="375" height="375" rx="17.25" fill="#000000" />
+  <path
+    transform="translate(84.108568, 302.248811)"
+    fill="#ffffff"
+    d="M 180.921875 -238.8125 L 180.921875 -197.46875 L 131.640625 -197.46875 L 131.640625 -41.53125 L 180.921875 -41.53125 L 180.921875 0 L 25.84375 0 L 25.84375 -41.53125 L 75.125 -41.53125 L 75.125 -197.46875 L 25.84375 -197.46875 L 25.84375 -238.8125 Z"
+  />
+</svg>


### PR DESCRIPTION
## Summary
- Header navlink and favicon still used the old lucide "italic I" placeholder icon
- Swapped both to the rounded-square serif "I" mark that igormcsouza.github.io already uses (matches `logo-light.svg`/`logo-dark.svg` on the main site)
- Navlink uses a new `Logo` component with `currentColor`/`hsl(var(--background))` so it tracks light/dark theme automatically, same as the old icon did

Fixes #36

## Test plan
- [x] `npm run lint`
- [x] `npm run build:e2e`
- [x] `npx playwright test` (34 passed, 2 skipped — includes favicon + logo navlink e2e tests)