### PR TITLE
Add DDD architecture article

### DIFF
--- a/content/domain-driven-design-architecture-that-grows-with-your-business.mdx
+++ b/content/domain-driven-design-architecture-that-grows-with-your-business.mdx
@@ -1,40 +1,53 @@
 ---
 title: "Domain-Driven Design: Architecture That Grows with Your Business"
-description: Every FastAPI app starts with routers, schemas, services and repositories. Here's what breaks as the business grows, and how Domain-Driven Design's layers fix it without a rewrite.
+description: fastapi-best-practices already groups code by feature. Here's the gap that's left, the two ways Domain-Driven Design closes it, and how to pick between them.
 author: Igor Souza
 date: 2026-08-09
 published: true
 tags: ["python", "fastapi", "architecture", "ddd", "clean-architecture"]
 ---
-Open any FastAPI project six months after the first commit and you'll usually find the same four folders: `routers/`, `schemas/`, `services/`, `repositories/`. It's the layout [zhanymkanov's fastapi-best-practices](https://github.com/zhanymkanov/fastapi-best-practices) popularized, and for good reason, it's simple, it's consistent, and it gets a small app shipped fast. Then the app grows, and something predictable happens: `services/post_service.py` starts importing `user_service.py`, which imports `notification_service.py`, and a "quick" change to how a post gets published means reading four files to find out which one actually owns the rule you're trying to change.
+Open the file tree in [zhanymkanov's fastapi-best-practices](https://github.com/zhanymkanov/fastapi-best-practices), by far the most-copied FastAPI structure out there, and you won't find one global `routers/` folder holding every endpoint in the app. You'll find this:
 
-This is the exact problem Domain-Driven Design was written to solve, just not the way most people first hear about it. You don't need aggregates, bounded contexts, or a whiteboard full of arrows to get real value out of it. You need one idea, applied consistently: **organize code around what the business does, not around the technical role each file plays.** This post is about turning that idea into folders you can actually build with FastAPI, starting from the structure you probably already have.
-
-## The layout everyone copies (and outgrows)
-
-The default shape looks something like this:
+## The layout everyone actually copies
 
 ```text
-app/
-├── routers/
-│   └── posts.py
-├── schemas/
-│   └── post.py
-├── services/
-│   └── post_service.py
-├── repositories/
-│   └── post_repository.py
-└── models/
-    └── post.py
+src
+├── auth
+│   ├── router.py
+│   ├── schemas.py
+│   ├── models.py
+│   ├── service.py
+│   ├── dependencies.py
+│   ├── constants.py
+│   ├── exceptions.py
+│   └── utils.py
+├── posts
+│   ├── router.py
+│   ├── schemas.py
+│   ├── models.py
+│   ├── service.py
+│   └── ...
+├── aws
+│   ├── client.py
+│   ├── schemas.py
+│   └── ...
+├── config.py
+├── models.py
+├── database.py
+└── main.py
 ```
 
-Each folder answers "what kind of thing is this" from FastAPI's point of view: `routers/` handles HTTP, `schemas/` handles Pydantic validation, `services/` handles "logic," `repositories/` handles the database. That grouping is honest about the framework, but it's silent about the business. Nothing in that tree tells you what a "post" is allowed to do, what makes one valid, or what "publishing" actually means, that knowledge is scattered wherever it was convenient to write it at the time, usually inside `services/`, because that's the folder with the fewest rules about what belongs in it.
+Each feature gets its own module, `auth`, `posts`, `aws`, and every module carries its own router, schemas, models and service together. That's already a meaningful step in the direction this post is going: code is grouped by what the business does, `auth`, `posts`, not by technical role. It's the same move Flask's blueprints make, group routes by feature instead of dumping them all in one file, and the fastapi-best-practices guide leads with it as its very first recommendation.
 
 <Callout icon="💡" type="informative">
-If this sounds familiar from a different framework, it should. Flask's blueprints exist to solve almost the same complaint, "everything is dumped in one place as the app grows", by letting you group routes by feature instead of by file type. Blueprints fix *where* code lives. They don't say anything about *which way the dependencies point*, which turns out to be the actual problem, as we'll get to shortly.
+Worth being precise here, since this repo gets cited, and misquoted, constantly: it does **not** recommend one giant `routers/` package for the whole app. That flatter, everything-grouped-by-technical-role layout is a pattern teams sometimes drift into on their own, often while half-remembering this exact guide, not what it actually says. If anything, the real recommendation is already halfway to where this post is headed.
 </Callout>
 
-Left alone, this structure degrades in a specific, recognizable way: business rules leak into whichever layer happens to run first (usually the router, sometimes the Pydantic schema's `validator`), services accumulate cross-imports because nothing stops `PostService` from reaching into `UserService`'s internals, and "where does this rule live" stops having a one-file answer. None of this is a FastAPI problem, or even a Python problem. It's what happens to any codebase organized by technical role once the business logic outgrows a single file per role.
+So where's the crack, if the top level is already this reasonable? Inside each module. Open `posts/service.py` six months into a growing app and it's usually carrying three unrelated jobs at once: deciding what makes a post valid, deciding what "publishing" means, and orchestrating the call down into `posts/models.py`'s ORM layer. None of those three jobs is wrong to have. Bundling all three into one file with no name for the difference between them is the problem, and it's the same problem a flat, technical-role-first structure has, just contained to a smaller blast radius. There's still no single place that answers "what is a valid Post," independent of whether the caller is `posts/router.py`, a Celery task, or a test.
+
+<Callout icon="⚡" type="warning">
+Grouping by feature (what `auth/`, `posts/`, and Flask blueprints all do) answers *where* code for a feature lives. It says nothing about *which way the dependencies inside that feature should point*, or which file owns a business rule versus which one just orchestrates it. That gap, not the folder layout, is what Domain-Driven Design's layering actually closes.
+</Callout>
 
 ## What "domain-driven" actually means
 
@@ -44,19 +57,19 @@ That's a way of thinking, not a folder structure. But folders are where a way of
 
 ## Renaming what you already have
 
-Here's the useful part: three of your four existing folders already correspond to a real architectural layer, they're just missing a name and, more importantly, missing a rule about what they're *not* allowed to contain. This mapping, and the emphasis on keeping frameworks at the edges, is the same shape Robert C. Martin describes in *Clean Architecture* (2017) and that Harry Percival and Bob Gregory build a full Python example around in *Architecture Patterns with Python* (2020, free at [cosmicpython.com](https://www.cosmicpython.com/)):
+Here's the useful part: three of the four files already inside each module correspond to a real architectural layer, they're just missing a name and, more importantly, missing a rule about what they're *not* allowed to contain. This mapping, and the emphasis on keeping frameworks at the edges, is the same shape Robert C. Martin describes in *Clean Architecture* (2017) and that Harry Percival and Bob Gregory build a full Python example around in *Architecture Patterns with Python* (2020, free at [cosmicpython.com](https://www.cosmicpython.com/)):
 
-| Today | Layer | Job | Must **not** contain |
+| Inside `posts/` today | Layer | Job | Must **not** contain |
 |---|---|---|---|
-| `routers/` + `schemas/` | **Interface** | Translate HTTP requests into calls the app understands, and results back into HTTP responses | Business rules, validation beyond "is this JSON shaped right" |
-| `services/` | **Application** | Orchestrate a use case: fetch what's needed, ask the domain to do the work, save the result | Business rules, direct SQL/ORM calls |
-| `repositories/` + `models/` | **Infrastructure** | Concrete I/O: talk to Postgres, Redis, an external API | Business rules, decisions about *whether* something should happen |
+| `router.py` + `schemas.py` | **Interface** | Translate HTTP requests into calls the app understands, and results back into HTTP responses | Business rules, validation beyond "is this JSON shaped right" |
+| `service.py` | **Application** | Orchestrate a use case: fetch what's needed, ask the domain to do the work, save the result | Business rules, direct SQL/ORM calls |
+| `models.py` | **Infrastructure** | Concrete I/O: talk to Postgres, Redis, an external API | Business rules, decisions about *whether* something should happen |
 | *(nothing today)* | **Domain** | Entities, value objects, and the business rules that decide what's valid and what happens next | Any import of FastAPI, SQLAlchemy, or anything else framework-specific |
 
-The one genuinely new folder is `domain/`, and it's the one that matters most, because it's where the rule "a post needs a title and a body" or "a post can't be published twice" actually belongs. Not in a Pydantic validator, not in a service method, not in a database constraint discovered the hard way, in one file, named after the business concept it protects.
+The one genuinely new file is `domain.py`, and it's the one that matters most, because it's where the rule "a post needs a title and a body" or "a post can't be published twice" actually belongs. Not in a Pydantic validator, not in a service method, not in a database constraint discovered the hard way, in one file, named after the business concept it protects. Notice this split happens **inside each module**, `auth/domain.py` sitting next to `posts/domain.py`, not as four new folders cutting across the whole app. That keeps the change scoped to one feature at a time, and it echoes Evans' own idea of a bounded context: each feature gets to define its rules independently of the others.
 
 <Callout icon="⚡" type="warning">
-Renaming `services/` to `application/` and calling it done is the most common way to fake this migration. If the folder still reaches into SQLAlchemy directly, or still decides business rules inline, you've relabeled the junk drawer, not fixed it. The names only earn their keep once the dependency rule below is actually true.
+Renaming `service.py` to `application.py` and calling it done is the most common way to fake this migration. If the file still reaches into SQLAlchemy directly, or still decides business rules inline, you've relabeled the junk drawer, not fixed it. The names only earn their keep once the dependency rule below is actually true.
 </Callout>
 
 ## The rule that actually matters: dependencies point inward
@@ -70,18 +83,64 @@ Here's the part that's easy to skip and expensive to skip: **the domain layer mu
                               infrastructure ───implements───────┘
 ```
 
-This is Martin's dependency rule from *Clean Architecture*, stripped to the one sentence worth remembering: **frameworks and databases are details, and details should depend on policy, not the other way around.** The domain layer is the policy. FastAPI and Postgres are details, replaceable ones, if the arrows point the right way.
+This is Martin's dependency rule from *Clean Architecture*, stripped to the one sentence worth remembering: **frameworks and databases are details, and details should depend on policy, not the other way around.** The domain layer is the policy. FastAPI and Postgres are details, replaceable ones, if the arrows point the right way. And this exact diagram repeats once per module: `auth/router.py → auth/service.py → auth/domain.py`, `posts/router.py → posts/service.py → posts/domain.py`, and so on, each feature enforcing its own boundary independently.
 
 The payoff isn't aesthetic. If `PublishPost` (application) depends on `PostRepository` (an interface the domain defines) rather than on `SqlPostRepository` (a concrete infrastructure class), you can hand it an in-memory fake in a test and exercise every business rule without a database, a running FastAPI app, or a mock library in sight. That's the actual reason to do any of this: not tidier folders, but business logic you can test and change without dragging the rest of the stack along.
 
+## Two ways to arrange the layers
+
+Everything above tells you *what* the four layers are, but not *where the folder boundaries go*, and that turns out to have two reasonable answers. Which one to pick is a real decision, not just taste, so here's both, plus how to choose.
+
+**Feature-first (nest the layers inside each module).** Keep `auth/`, `posts/`, `aws/` exactly as fastapi-best-practices ships them, and add one new file per module:
+
+```text
+posts
+├── router.py       # interface
+├── schemas.py      # interface
+├── domain.py       # domain (new)
+├── service.py      # application (thinned down)
+└── models.py       # infrastructure
+```
+
+This is the smallest possible diff from what you already have, everything about "posts" still lives in one folder, and it's what the worked example below uses.
+
+**Layer-first (the textbook Clean Architecture / hexagonal shape).** Flip the axis: layers become the top-level folders, and each one holds one file per feature. This is close to how Percival and Gregory actually lay out their own example application in *Architecture Patterns with Python* (`domain/`, `service_layer/`, `adapters/`):
+
+```text
+src
+├── domain/
+│   ├── posts.py
+│   └── auth.py
+├── application/
+│   ├── publish_post.py
+│   └── register_user.py
+├── infrastructure/
+│   ├── sql_post_repository.py
+│   └── sql_user_repository.py
+└── interface/
+    ├── posts_router.py
+    └── auth_router.py
+```
+
+Same four responsibilities, same dependency direction, just organized as columns instead of nested inside each feature folder.
+
+| | Feature-first | Layer-first |
+|---|---|---|
+| Diff from fastapi-best-practices | Minimal, add one file per module | Larger, restructure the whole tree |
+| Changing one feature | Touch one folder | Touch up to four folders |
+| Enforcing "domain imports nothing" | Code review, or a per-module lint rule | One `import-linter`/Deptrac rule for the whole codebase |
+| Best fit | Small-to-medium team, each feature has one entry point (its own REST routes) | Domain shared across several entry points (HTTP + CLI + worker), or a team that wants the boundary machine-checked, not just reviewed |
+
+Neither is "more correct" DDD, Evans never mandated a folder layout, Martin's circles are a diagram, not a directory listing. Start feature-first if you're evolving an existing fastapi-best-practices app, which covers most real migrations; reach for layer-first when the domain layer has outgrown a single HTTP-shaped module or you want CI, not a reviewer, catching a stray `import sqlalchemy` inside `domain/`.
+
 ## Worked example: publishing a post
 
-Same use case, both layouts, so the difference is concrete instead of abstract.
+Same use case, both layouts, so the difference is concrete instead of abstract. This uses the feature-first arrangement from above, since it's the smaller step from what you already have.
 
 **Default layout.** The validation rule about what makes a post valid lives inside `PostService`, which is nominally "just orchestration":
 
 ```python {5,6,7} showLineNumbers
-# services/post_service.py
+# posts/service.py
 class PostService:
     def __init__(self, repo: PostRepository):
         self.repo = repo
@@ -100,7 +159,7 @@ Nothing here is wrong, exactly, but notice the rule "a post needs a title and a 
 **DDD layout.** The same rule moves into the one place that owns it:
 
 ```python {6,7,8,9} showLineNumbers
-# domain/post.py
+# posts/domain.py
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -124,9 +183,9 @@ class PostRepository(Protocol):
 ```
 
 ```python showLineNumbers
-# application/publish_post.py
+# posts/application.py
 from dataclasses import dataclass
-from domain.post import Post, PostRepository
+from posts.domain import Post, PostRepository
 
 @dataclass
 class PublishPost:
@@ -139,8 +198,8 @@ class PublishPost:
 ```
 
 ```python showLineNumbers
-# infrastructure/sql_post_repository.py
-from domain.post import Post
+# posts/infrastructure.py
+from posts.domain import Post
 
 class SqlPostRepository:  # implements PostRepository, no base class required
     def __init__(self, session):
@@ -154,9 +213,9 @@ class SqlPostRepository:  # implements PostRepository, no base class required
 ```
 
 ```python showLineNumbers
-# interface/routers/posts.py
+# posts/router.py
 from fastapi import APIRouter, Depends
-from application.publish_post import PublishPost
+from posts.application import PublishPost
 
 router = APIRouter()
 
@@ -183,34 +242,34 @@ def test_publish_post_marks_it_published():
     assert post.published is True
 ```
 
-No database, no FastAPI `TestClient`, no mocking framework, just the business rule, isolated and fast to run. That's the concrete version of "ports and adapters" that Percival and Gregory build their entire book around: the domain defines the port (`PostRepository`), infrastructure supplies the adapter (`SqlPostRepository`), and swapping the adapter never touches the port or the business logic behind it.
+No database, no FastAPI `TestClient`, no mocking framework, just the business rule, isolated and fast to run. That's the concrete version of "ports and adapters" that Percival and Gregory build their entire book around: the domain defines the port (`PostRepository`), infrastructure supplies the adapter (`SqlPostRepository`), and swapping the adapter never touches the port or the business logic behind it. Had this used the layer-first arrangement instead, the classes above wouldn't change at all, only their addresses would: `posts/domain.py` becomes `domain/posts.py`, `posts/application.py` becomes `application/publish_post.py`, and so on. The behavior, and the test, are identical either way, which is the point: the folder axis is a navigation choice, the dependency direction is the architecture.
 
 ## Don't cargo-cult it
 
 None of this is free. Four layers instead of two is more files, more indirection, and more places to look up a definition, and that cost is only worth paying once the domain has enough real rules to protect. Percival and Gregory are explicit about this in *Architecture Patterns with Python*: start simple, and grow into ports, entities, and a real domain layer only once complexity actually demands it.
 
 <Callout icon="⚡" type="danger">
-If your "service" layer is entirely `def get(self, id): return self.repo.get(id)`, you don't have a missing domain layer, you have a CRUD app, and a CRUD app doesn't need one. Adding `domain/` and `application/` folders to a project with no real business rules just adds ceremony around code that was never going to change independently anyway.
+If `posts/service.py` is entirely `def get(self, id): return self.repo.get(id)`, you don't have a missing domain layer, you have a CRUD app, and a CRUD app doesn't need one, feature-first or layer-first. Adding a `domain.py` (or a whole `domain/` folder) to a module with no real business rules just adds ceremony around code that was never going to change independently anyway.
 </Callout>
 
 The tell that you've earned this structure isn't the size of the codebase, it's the shape of the bugs you're getting: rules duplicated in two places and drifting apart, a router doing three unrelated things because "that's where the request comes in," or a test suite that can't exercise business logic without spinning up a real database. When those show up, the layers pay for themselves. Before that, they're just overhead.
 
 ## Bringing it into an existing app, one slice at a time
 
-You don't need a rewrite to get here, and attempting one is how these migrations stall out. Instead, pick the single most tangled service, the one you dread changing, and work through it in order:
+You don't need a rewrite to get here, and attempting one is how these migrations stall out. The feature-first version, in particular, is designed to be added incrementally: pick the single most tangled `service.py`, the one you dread changing, and work through it in order:
 
-1. **Extract the validation and business rules** out of that service into a small dataclass or class under `domain/`, the way `Post.__post_init__` does above.
-2. **Define a `Protocol`** for whatever that service persists or fetches, owned by the domain, describing only what the business logic actually needs.
-3. **Point the existing repository at that `Protocol`** implicitly, Python's structural typing means an existing class that already has a matching `save` method satisfies it with zero changes.
-4. **Thin the service down** into an application-layer use case that only orchestrates: call the domain, call the repository, done.
-5. **Leave the router and schema alone.** They're already close to the interface layer's job; they don't need to move on day one.
-6. **Repeat per feature**, not per file. A `domain/post.py` next to an untouched `services/user_service.py` is a valid, working intermediate state, not a mess to apologize for.
+1. **Extract the validation and business rules** out of `service.py` into a small dataclass or class in a new `domain.py` next to it, the way `Post.__post_init__` does above.
+2. **Define a `Protocol`** for whatever that module persists or fetches, owned by `domain.py`, describing only what the business logic actually needs.
+3. **Point the existing `models.py` at that `Protocol`** implicitly, Python's structural typing means an existing class that already has a matching `save` method satisfies it with zero changes.
+4. **Thin `service.py` down** into an application-layer use case that only orchestrates: call the domain, call the repository, done. Renaming the file to `application.py` is optional, and can wait.
+5. **Leave `router.py` and `schemas.py` alone.** They're already exactly where the interface layer belongs; they don't need to move on day one.
+6. **Repeat per module**, not per file, and not all at once. A `posts/domain.py` next to an untouched `auth/service.py` is a valid, working intermediate state, not a mess to apologize for.
 
-Each step is small enough to review on its own, and the app runs correctly after every single one of them, which is the actual point: architecture is something you grow into, the same way the business itself grows, not something you stop and rebuild for.
+Each step is small enough to review on its own, and the app runs correctly after every single one of them, which is the actual point: architecture is something you grow into, the same way the business itself grows, not something you stop and rebuild for. Moving to layer-first later, if you ever need to, is a bigger, more deliberate jump, plan it as its own piece of work rather than smuggling it into an unrelated feature change.
 
 ## Conclusion
 
-None of the four layers here are new ideas, `routers/`, `schemas/`, `services/`, and `repositories/` were already most of the way there. What was missing was a name for the business rules that didn't fit anywhere, and a rule about which direction the imports are allowed to point. Get the direction right, domain depending on nothing, everything else depending on domain, and the rest, testability, a home for logic that doesn't belong to any one endpoint, the ability to swap Postgres for something else without touching a business rule, follows from that one decision almost automatically.
+None of the four layers here are new ideas, `router.py`, `schemas.py`, `service.py`, and `models.py`, grouped by feature, were already most of the way there. What was missing was a name for the business rules that didn't fit anywhere, and a rule about which direction the imports are allowed to point. Get the direction right, domain depending on nothing, everything else depending on domain, and the rest, testability, a home for logic that doesn't belong to any one endpoint, the ability to swap Postgres for something else without touching a business rule, follows from that one decision almost automatically. Whether you enforce it by nesting the layers inside each feature or by making them the top-level folders is a real choice, but it's a secondary one.
 
 Start from the structure you already have. Rename nothing until the dependency direction actually changes underneath it.
 

--- a/content/domain-driven-design-architecture-that-grows-with-your-business.mdx
+++ b/content/domain-driven-design-architecture-that-grows-with-your-business.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Domain-Driven Design: Architecture That Grows with Your Business"
-description: Business rules that scatter across routers, schemas and models are a domain problem, not a FastAPI one. Here's how Domain-Driven Design fixes it, in two flavors, and how to choose between them.
+description: Business rules that scatter across routers, schemas and models are a domain problem, not a FastAPI one. Here's how Evans' own layered architecture fixes it, one bounded context at a time.
 author: Igor Souza
 date: 2026-08-09
 published: true
@@ -8,7 +8,7 @@ tags: ["python", "fastapi", "architecture", "ddd", "clean-architecture"]
 ---
 Every FastAPI project I've built starts the same way: a `posts` folder, a router, a couple of Pydantic schemas, a service function, a database model. It works cleanly for weeks. Then one day I need to change a single rule, say a post shouldn't be publishable without a body, and I can't find the one place that rule actually lives. It's half-written in a Pydantic validator, half-assumed by the router, and the database has its own opinion via a `NOT NULL` constraint. Three sources of truth for one sentence of business logic, and no way to change it without touching all three.
 
-That's not really a FastAPI problem. It's what happens to any growing application that never gave its business rules a home of their own. Domain-Driven Design, the term Eric Evans coined in *Domain-Driven Design: Tackling Complexity in the Heart of Software* (2003), is the name for fixing exactly that: organizing code around what the business does, a post, publishing, instead of around whatever technical layer happens to run first. The idea itself doesn't tell you which folder anything belongs in, so this post is about two well-known sources that turn it into an actual FastAPI project layout, and how to pick between them.
+That's not really a FastAPI problem. It's what happens to any growing application that never gave its business rules a home of their own. Domain-Driven Design, the term Eric Evans coined in *Domain-Driven Design: Tackling Complexity in the Heart of Software* (2003), is the name for fixing exactly that: organizing code around what the business does, a post, publishing, instead of around whatever technical layer happens to run first. Getting there in a FastAPI project turns out to need two pieces, one most teams already have and one Evans wrote down two decades ago, and this post is about combining them.
 
 ## fastapi-best-practices already gets you halfway
 
@@ -43,18 +43,16 @@ src
 
 That's a good instinct: code about "posts" lives together, instead of one `routers/` folder holding every endpoint in the app regardless of what it's for. It's the same move Flask's blueprints make, grouping by feature instead of by file type, and fastapi-best-practices leads with it as its very first recommendation. What it doesn't do is separate the business rule from the file that happens to run it. `service.py` ends up holding validation, orchestration, and the call down into the database all at once, so a rule like "a post needs a title and a body" still has no single home, it's just contained to one folder instead of scattered across the whole app.
 
-## Turning that into four layers
+## The layers, straight from Evans
 
-This is where the more classic DDD sources pick up: Robert C. Martin's *Clean Architecture* (2017), and Harry Percival and Bob Gregory's *Architecture Patterns with Python* (2020, free at [cosmicpython.com](https://www.cosmicpython.com/)), which builds a full Python example around the same ideas. Both describe the same four responsibilities, and each file already inside a fastapi-best-practices module maps onto one of them:
+The four-layer split isn't a later invention; it's in the original book. Evans devotes a chapter of *Domain-Driven Design* to what he calls Layered Architecture: User Interface, Application, Domain, and Infrastructure, with one explicit goal, keep the Domain layer isolated so it can express business rules without getting tangled up in the other three. `interface` in this post is Evans' User Interface (or Presentation) layer, just renamed for a web API where there's no actual UI, only routes and schemas. Martin's *Clean Architecture* (2017) and Percival and Gregory's *Architecture Patterns with Python* (2020, free at [cosmicpython.com](https://www.cosmicpython.com/)) didn't invent these four layers, they took Evans' isolation goal and made it mechanical: instead of just isolating the domain by convention, the domain defines interfaces and everything else depends on it, which is the dependency rule below. Each file already inside a fastapi-best-practices module maps onto one of Evans' four layers:
 
 | Inside `posts/` today | Layer | Job | Must **not** contain |
 |---|---|---|---|
-| `router.py` + `schemas.py` | **Interface** | Translate HTTP requests into calls the app understands, and results back into HTTP responses | Business rules, validation beyond "is this JSON shaped right" |
+| `router.py` + `schemas.py` | **Interface** (Evans: User Interface) | Translate HTTP requests into calls the app understands, and results back into HTTP responses | Business rules, validation beyond "is this JSON shaped right" |
 | `service.py` | **Application** | Orchestrate a use case: fetch what's needed, ask the domain to do the work, save the result | Business rules, direct SQL/ORM calls |
 | `models.py` | **Infrastructure** | Concrete I/O: talk to Postgres, Redis, an external API | Business rules, decisions about *whether* something should happen |
 | *(nothing today)* | **Domain** | Entities, value objects, and the business rules that decide what's valid and what happens next | Any import of FastAPI, SQLAlchemy, or anything else framework-specific |
-
-The one genuinely new file is `domain.py`, and it's the one that matters most: it's where "a post needs a title and a body" actually belongs, in one place, named after the business concept it protects, instead of split across a validator, a service method, and a database constraint. This split happens **inside each module**, `auth/domain.py` sitting next to `posts/domain.py`, which keeps the change scoped to one feature at a time and echoes Evans' own idea of a bounded context: each feature gets to define its rules independently of the others.
 
 ## The rule that actually matters: dependencies point inward
 
@@ -67,59 +65,52 @@ The domain layer must not depend on anything outside it. No FastAPI imports, no 
                               infrastructure ───implements───────┘
 ```
 
-This is Martin's dependency rule, stripped to one sentence: **frameworks and databases are details, and details should depend on policy, not the other way around.** The domain layer is the policy; FastAPI and Postgres are details, replaceable ones, if the arrows point the right way. The diagram repeats once per module, `auth/router.py → auth/service.py → auth/domain.py`, `posts/router.py → posts/service.py → posts/domain.py`, each feature enforcing its own boundary independently.
+This is the sentence worth remembering: **frameworks and databases are details, and details should depend on policy, not the other way around.** The domain layer is the policy; FastAPI and Postgres are details, replaceable ones, if the arrows point the right way. The diagram repeats once per bounded context, `auth/router.py → auth/service.py → auth/domain.py`, `posts/router.py → posts/service.py → posts/domain.py`, each context enforcing its own boundary independently.
 
 The payoff isn't aesthetic. If a `PublishPost` use case depends on a `PostRepository` interface the domain defines, rather than on a concrete `SqlPostRepository`, you can hand it an in-memory fake in a test and exercise every business rule without a database, a running FastAPI app, or a mock library in sight. That's the actual reason to do any of this: not tidier folders, but business logic you can test and change without dragging the rest of the stack along.
 
-## Two ways to arrange the layers
+## One bounded context, four layers
 
-Knowing the four layers still leaves one open question: where do the folder boundaries actually go? The two sources above answer it differently, and both answers are legitimate.
-
-**Feature-first, following fastapi-best-practices.** Keep `auth/`, `posts/`, `aws/` exactly as they ship, and add one new file per module:
+Evans' other core idea, alongside the layers, is the bounded context: a boundary around one part of the business, `posts`, `auth`, inside which a term like "post" means exactly one thing and the rules about it live together. fastapi-best-practices already drew that boundary for you, `posts/`, `auth/`, `aws/` are bounded contexts in everything but name. So the layers belong *inside* each one, not spread across the whole app as four folders that cut through every context at once:
 
 ```text
 posts
-├── router.py       # interface
-├── schemas.py      # interface
-├── domain.py       # domain (new)
-├── service.py      # application (thinned down)
-└── models.py       # infrastructure
+├── router.py          # interface
+├── schemas.py         # interface
+├── domain.py           # domain (new)
+├── application.py      # application (was service.py)
+└── infrastructure.py   # infrastructure (was models.py)
 ```
 
-This is the smallest possible diff from what you already have; everything about "posts" still lives in one folder. It's what the worked example below uses.
-
-**Layer-first, following Clean Architecture / Percival and Gregory more literally.** Flip the axis: layers become the top-level folders, each one holding one file per feature, close to how *Architecture Patterns with Python*'s own example app is laid out (`domain/`, `service_layer/`, `adapters/`):
+That's the whole change for a context small enough to need one file per layer. It grows into subfolders the moment a layer needs more than one file, which happens as soon as a context covers more than a single entity or use case:
 
 ```text
-src
+posts
+├── router.py
+├── schemas.py
 ├── domain/
-│   ├── posts.py
-│   └── auth.py
+│   ├── post.py           # Post entity, PostRepository protocol
+│   └── comment.py        # Comment entity, same bounded context
 ├── application/
 │   ├── publish_post.py
-│   └── register_user.py
-├── infrastructure/
-│   ├── sql_post_repository.py
-│   └── sql_user_repository.py
-└── interface/
-    ├── posts_router.py
-    └── auth_router.py
+│   └── delete_comment.py
+└── infrastructure/
+    ├── sql_post_repository.py
+    └── sql_comment_repository.py
 ```
 
-Same four responsibilities, same dependency direction, organized as columns instead of nested inside each feature folder.
+What actually lives in each one:
 
-| | Feature-first | Layer-first |
-|---|---|---|
-| Diff from fastapi-best-practices | Minimal, add one file per module | Larger, restructure the whole tree |
-| Changing one feature | Touch one folder | Touch up to four folders |
-| Enforcing "domain imports nothing" | Code review, or a per-module lint rule | One `import-linter`/Deptrac rule for the whole codebase |
-| Best fit | Small-to-medium team, each feature has one entry point (its own REST routes) | Domain shared across several entry points (HTTP + CLI + worker), or a team that wants the boundary machine-checked, not just reviewed |
+- **`domain/`**: Entities like `Post` (an object with an identity and a lifecycle, `__post_init__` enforcing "needs a title and a body"), Value Objects for anything defined purely by its data (a `Slug`, a `PostStatus`), Domain Services for a rule that spans more than one entity, and the repository `Protocol`s the layer needs but never implements.
+- **`application/`**: one use case per user-facing operation, `PublishPost`, `DeleteComment`, each a small class or function that fetches what it needs, asks the domain to do the work, and saves the result. No business decisions here, only sequencing.
+- **`infrastructure/`**: concrete repository implementations (`SqlPostRepository`), ORM models, clients for anything external, S3, an email provider, a payment gateway.
+- **`router.py` + `schemas.py`**: FastAPI routes and Pydantic models, translating HTTP into a call on the application layer and the result back into a response. Evans' User Interface layer, under the name this post has been using for it.
 
-Neither is "more correct" DDD, Evans never mandated a folder layout, Martin's circles are a diagram, not a directory listing. Feature-first is the better starting point for evolving an existing fastapi-best-practices app, which covers most real migrations. Layer-first earns its cost once the domain layer has outgrown a single HTTP-shaped module, or once a team wants CI, not a reviewer, catching a stray `import sqlalchemy` inside `domain/`.
+Percival and Gregory's own example application in *Architecture Patterns with Python* puts these same four layers at the top level instead, `domain/`, `service_layer/`, `adapters/`, spanning the whole app. That reads naturally in their book because it only ever deals with one bounded context. The moment an app has more than one, `posts` and `auth` and `aws` all needing their own domain rules, nesting the layers inside each context keeps them separate the way Evans intended, instead of merging every context's entities into one shared `domain/` folder.
 
 ## Worked example: publishing a post
 
-Same use case, both layouts, so the difference is concrete instead of abstract. This uses the feature-first arrangement, since it's the smaller step from what you already have.
+Same use case, both layouts, so the difference is concrete instead of abstract. This uses the single-file version of the layers, since `posts` is small enough that it doesn't need the subfolders yet.
 
 **Default layout.** The validation rule about what makes a post valid lives inside `PostService`, which is nominally "just orchestration":
 
@@ -226,14 +217,14 @@ def test_publish_post_marks_it_published():
     assert post.published is True
 ```
 
-No database, no FastAPI `TestClient`, no mocking framework, just the business rule, isolated and fast to run. That's the concrete version of "ports and adapters" Percival and Gregory build their entire book around: the domain defines the port (`PostRepository`), infrastructure supplies the adapter (`SqlPostRepository`), and swapping the adapter never touches the port or the business logic behind it. Had this used the layer-first arrangement instead, the classes wouldn't change at all, only their addresses would: `posts/domain.py` becomes `domain/posts.py`, `posts/application.py` becomes `application/publish_post.py`, and so on. The behavior, and the test, are identical either way, the folder axis is a navigation choice, the dependency direction is the architecture.
+No database, no FastAPI `TestClient`, no mocking framework, just the business rule, isolated and fast to run. That's the concrete version of "ports and adapters" Percival and Gregory build their entire book around: the domain defines the port (`PostRepository`), infrastructure supplies the adapter (`SqlPostRepository`), and swapping the adapter never touches the port or the business logic behind it. If `posts` later grows a second entity, `posts/domain.py` becomes a `posts/domain/` folder with `post.py` and `comment.py` inside it, same classes, same test, just one file split into two once there's a reason to.
 
 ## Where this goes wrong
 
 Four layers instead of two is more files, more indirection, and more places to look up a definition, and that cost is only worth paying once the domain has enough real rules to protect. Percival and Gregory are explicit about this: start simple, and grow into ports, entities, and a real domain layer only once complexity actually demands it.
 
 <Callout icon="⚡" type="danger">
-If `posts/service.py` is entirely `def get(self, id): return self.repo.get(id)`, that's not a missing domain layer, that's a CRUD app, and a CRUD app doesn't need one, feature-first or layer-first. Adding a `domain.py` to a module with no real business rules just adds ceremony around code that was never going to change independently anyway.
+If `posts/service.py` is entirely `def get(self, id): return self.repo.get(id)`, that's not a missing domain layer, that's a CRUD app, and a CRUD app doesn't need one. Adding a `domain.py` to a module with no real business rules just adds ceremony around code that was never going to change independently anyway.
 </Callout>
 
 The other common failure is doing the rename without doing the work: calling `service.py` `application.py` while it still reaches into SQLAlchemy directly, or still decides business rules inline. That relabels the junk drawer, it doesn't fix it, the names only earn their keep once the dependency rule actually holds.
@@ -242,20 +233,21 @@ The tell that you've earned this structure isn't the size of the codebase, it's 
 
 ## Bringing it into an existing app, one slice at a time
 
-You don't need a rewrite to get here, attempting one is how these migrations stall out. The feature-first version is built to be added incrementally: pick the single most tangled `service.py`, the one you dread changing, and work through it in order.
+You don't need a rewrite to get here, attempting one is how these migrations stall out. This is built to be added incrementally, one bounded context at a time: pick the single most tangled `service.py`, the one you dread changing, and work through it in order.
 
 1. **Extract the validation and business rules** out of `service.py` into a small dataclass or class in a new `domain.py` next to it, the way `Post.__post_init__` does above.
-2. **Define a `Protocol`** for whatever that module persists or fetches, owned by `domain.py`, describing only what the business logic actually needs.
+2. **Define a `Protocol`** for whatever that context persists or fetches, owned by `domain.py`, describing only what the business logic actually needs.
 3. **Point the existing `models.py` at that `Protocol`** implicitly, Python's structural typing means an existing class that already has a matching `save` method satisfies it with zero changes.
 4. **Thin `service.py` down** into an application-layer use case that only orchestrates: call the domain, call the repository, done. Renaming the file to `application.py` is optional, and can wait.
 5. **Leave `router.py` and `schemas.py` alone.** They're already exactly where the interface layer belongs.
-6. **Repeat per module**, not per file, and not all at once. A `posts/domain.py` next to an untouched `auth/service.py` is a valid, working intermediate state.
+6. **Repeat per bounded context**, not per file, and not all at once. A `posts/domain.py` next to an untouched `auth/service.py` is a valid, working intermediate state.
+7. **Split a single file into a subfolder only when it needs a second file.** `posts/domain.py` becomes `posts/domain/` the day `posts` grows a second entity, not before.
 
-Each step is small enough to review on its own, and the app runs correctly after every single one of them, which is the actual point: architecture is something you grow into, the same way the business itself grows. Moving to layer-first later, if the domain ever outgrows a single module, is a bigger, more deliberate jump worth planning as its own piece of work, rather than folding it into an unrelated feature change.
+Each step is small enough to review on its own, and the app runs correctly after every single one of them, which is the actual point: architecture is something you grow into, the same way the business itself grows.
 
 ## Conclusion
 
-`router.py`, `schemas.py`, `service.py`, and `models.py`, grouped by feature, were already most of the way to a domain-driven structure. What was missing was a name for the business rules that didn't fit anywhere, and a rule about which direction the imports are allowed to point. Get the direction right, domain depending on nothing, everything else depending on domain, and the rest, testability, a home for logic that doesn't belong to any one endpoint, the ability to swap Postgres for something else without touching a business rule, follows from that decision almost automatically. Whether you enforce it by nesting the layers inside each feature or by making them the top-level folders is a real choice, but a secondary one, made once the first one, giving the business rules a home at all, is settled.
+`router.py`, `schemas.py`, `service.py`, and `models.py`, grouped by bounded context, were already most of the way to the layered architecture Evans described. What was missing was a name for the business rules that didn't fit anywhere, `domain.py`, and a rule about which direction the imports are allowed to point. Get the direction right, domain depending on nothing, everything else depending on domain, and the rest, testability, a home for logic that doesn't belong to any one endpoint, the ability to swap Postgres for something else without touching a business rule, follows from that decision almost automatically. Nest it inside each context, the way this post does, and it grows one bounded context at a time instead of asking for a whole-app restructure up front.
 
 ### Further Reading
 - [Domain-Driven Design: Tackling Complexity in the Heart of Software, Eric Evans (2003)](https://www.domainlanguage.com/ddd/)

--- a/content/domain-driven-design-architecture-that-grows-with-your-business.mdx
+++ b/content/domain-driven-design-architecture-that-grows-with-your-business.mdx
@@ -8,7 +8,9 @@ tags: ["python", "fastapi", "architecture", "ddd", "clean-architecture"]
 ---
 Every FastAPI project I've built starts the same way: a `posts` folder, a router, a couple of Pydantic schemas, a service function, a database model. It works cleanly for weeks. Then one day I need to change a single rule, say a post shouldn't be publishable without a body, and I can't find the one place that rule actually lives. It's half-written in a Pydantic validator, half-assumed by the router, and the database has its own opinion via a `NOT NULL` constraint. Three sources of truth for one sentence of business logic, and no way to change it without touching all three.
 
-That's not really a FastAPI problem. It's what happens to any growing application that never gave its business rules a home of their own. Domain-Driven Design, the term Eric Evans coined in *Domain-Driven Design: Tackling Complexity in the Heart of Software* (2003), is the name for fixing exactly that: organizing code around what the business does, a post, publishing, instead of around whatever technical layer happens to run first. Getting there in a FastAPI project turns out to need two pieces, one most teams already have and one Evans wrote down two decades ago, and this post is about combining them.
+It gets worse before it gets better, too. Six weeks later a second person adds a similar check for comments, copies the pattern they can see, the Pydantic validator, and misses the constraint sitting quietly in `service.py` because nothing pointed them at it. Now there are two rules that were supposed to be the same rule, drifting apart every time either one gets touched, until a comment ships that a post could never have gotten past. Nobody wrote a bug on purpose; the codebase just never had a single place to put "here's what a valid post looks like," so it ended up in three places that don't talk to each other. Multiply that by every entity in a growing app and the symptom becomes familiar: changing one sentence of business logic means grepping the codebase to find every place that sentence got half-implemented.
+
+That's not really a FastAPI problem. It's what happens to any growing application that never gave its business rules a home of their own. Domain-Driven Design, the term Eric Evans coined in *Domain-Driven Design: Tackling Complexity in the Heart of Software* (2003), is the name for fixing exactly that: organizing code around what the business does, a post, publishing, instead of around whatever technical layer happens to run first. Getting there in a FastAPI project turns out to need two pieces, one most teams already have and one Evans wrote down two decades ago, and this post is about combining them, in enough depth to actually build from.
 
 ## fastapi-best-practices already gets you halfway
 
@@ -99,12 +101,46 @@ posts
     └── sql_comment_repository.py
 ```
 
-What actually lives in each one:
+Here's what actually goes inside each one, and why, since the four one-line summaries above are easy to nod along with and hard to build from.
 
-- **`domain/`**: Entities like `Post` (an object with an identity and a lifecycle, `__post_init__` enforcing "needs a title and a body"), Value Objects for anything defined purely by its data (a `Slug`, a `PostStatus`), Domain Services for a rule that spans more than one entity, and the repository `Protocol`s the layer needs but never implements.
-- **`application/`**: one use case per user-facing operation, `PublishPost`, `DeleteComment`, each a small class or function that fetches what it needs, asks the domain to do the work, and saves the result. No business decisions here, only sequencing.
-- **`infrastructure/`**: concrete repository implementations (`SqlPostRepository`), ORM models, clients for anything external, S3, an email provider, a payment gateway.
-- **`router.py` + `schemas.py`**: FastAPI routes and Pydantic models, translating HTTP into a call on the application layer and the result back into a response. Evans' User Interface layer, under the name this post has been using for it.
+### The domain layer: entities, value objects, and domain services
+
+`domain/` is where Evans' vocabulary earns its keep, because it isn't just "the business logic folder," it holds three distinct kinds of object, and mixing them up is the most common way a domain layer turns back into a junk drawer.
+
+An **Entity** is anything with an identity that persists across changes: a `Post` is still the same post before and after it's published, so `Post` is an Entity, tracked by its `id`, mutable, with a lifecycle. A **Value Object** has no identity at all, it's defined entirely by its data, and two instances with the same data are simply the same value. A post's slug is a good example:
+
+```python showLineNumbers
+@dataclass(frozen=True)
+class Slug:
+    value: str
+
+    def __post_init__(self):
+        if not re.fullmatch(r"[a-z0-9-]+", self.value):
+            raise ValueError(f"invalid slug: {self.value!r}")
+```
+
+Two `Slug("hello-world")` objects are interchangeable, there's no "which one is the real one," and it's frozen because a Value Object that can mutate in place stops being one. `PostStatus`, a `Money` amount, an email address wrapper, all Value Objects: validate themselves on construction, and once built, they're just facts.
+
+A **Domain Service** is for a rule that doesn't naturally belong to any single entity, because it needs two of them to make sense. "A post can only be published if its author's account is in good standing" isn't `Post`'s rule or `Author`'s rule alone, it's a fact about the relationship between the two, so it becomes a small function or class of its own inside `domain/`, taking both as arguments:
+
+```python showLineNumbers
+def can_publish(post: Post, author: Author) -> bool:
+    return not post.published and author.is_in_good_standing()
+```
+
+Finally, `domain/` also owns the repository `Protocol`s, `PostRepository`, `CommentRepository`, the contracts the domain needs fulfilled, without ever importing whatever fulfills them.
+
+### The application layer: one file per use case
+
+`application/` holds use cases, and the discipline here is narrower than "orchestration logic": one file, one class or function, per thing a caller can actually trigger, `PublishPost`, `DeleteComment`, `ListPostsByAuthor`. Each use case follows the same three-step shape, fetch what's needed through a repository, ask the domain objects to do the work, save the result back through a repository, and nothing else. If a use case needs an `if` that decides *whether* something is allowed, that `if` was supposed to live in `domain/`, in an entity method or a domain service, not here. A useful test while writing one: could this class run unchanged against a completely different UI, a CLI command instead of an HTTP route? If yes, it's a clean use case; if it assumes something about HTTP requests or database sessions, some infrastructure or interface concern has leaked in.
+
+### The infrastructure layer: adapters for the outside world
+
+`infrastructure/` is where every `Protocol` the domain declared gets an actual body: `SqlPostRepository` backed by SQLAlchemy, but just as easily an `InMemoryPostRepository` for tests, or a second implementation backed by a different database entirely, all satisfying the same `PostRepository` contract because Python's structural typing doesn't ask for a shared base class. This is also where clients for anything external to the app live, an S3 client for image uploads, an email provider's SDK, a payment gateway, each wrapped behind whatever interface the domain or application layer actually needs from it, rather than that third-party SDK's own shape leaking into the rest of the codebase.
+
+### The interface layer: what callers actually see
+
+`router.py` and `schemas.py` are Evans' User Interface layer, under a name that fits an API with no actual UI. `schemas.py` defines the shape of requests and responses, and it's deliberately allowed to differ from the domain's own shape, a `PostCreate` schema has no `id` field, because the client isn't supposed to invent one, while the `Post` entity always has one once it exists. `router.py` wires an HTTP verb and path to a use case via FastAPI's `Depends`, converts the incoming schema into whatever primitive arguments that use case actually takes, and converts its return value back into a response schema. Nothing in this layer decides anything; it translates in both directions and gets out of the way.
 
 Percival and Gregory's own example application in *Architecture Patterns with Python* puts these same four layers at the top level instead, `domain/`, `service_layer/`, `adapters/`, spanning the whole app. That reads naturally in their book because it only ever deals with one bounded context. The moment an app has more than one, `posts` and `auth` and `aws` all needing their own domain rules, nesting the layers inside each context keeps them separate the way Evans intended, instead of merging every context's entities into one shared `domain/` folder.
 
@@ -247,7 +283,11 @@ Each step is small enough to review on its own, and the app runs correctly after
 
 ## Conclusion
 
-`router.py`, `schemas.py`, `service.py`, and `models.py`, grouped by bounded context, were already most of the way to the layered architecture Evans described. What was missing was a name for the business rules that didn't fit anywhere, `domain.py`, and a rule about which direction the imports are allowed to point. Get the direction right, domain depending on nothing, everything else depending on domain, and the rest, testability, a home for logic that doesn't belong to any one endpoint, the ability to swap Postgres for something else without touching a business rule, follows from that decision almost automatically. Nest it inside each context, the way this post does, and it grows one bounded context at a time instead of asking for a whole-app restructure up front.
+`router.py`, `schemas.py`, `service.py`, and `models.py`, grouped by bounded context, were already most of the way to the layered architecture Evans described in 2003, before Clean Architecture had a name and before cosmicpython existed to demonstrate it in Python. What was actually missing was two things, not one: a name for the business rules that didn't fit anywhere, `domain.py`, and a rule about which direction the imports are allowed to point, domain depending on nothing, everything else depending on domain. Neither shows up by accident. A `domain.py` file that still gets imported by `infrastructure.py`, or a `Post` entity that still imports `sqlalchemy`, has the right filename in the wrong place, and none of the payoff below follows from a filename alone.
+
+Get both things right and the rest stops being separate work: testability, because a use case built against a `Protocol` accepts a fake repository in a test without a database in sight; a single home for logic that doesn't belong to any one endpoint, so a CLI command and an HTTP route can call the same `PublishPost` use case instead of reimplementing "what makes a post valid" twice; the ability to swap Postgres for something else, or add a second, differently-backed implementation of the same repository, without touching a business rule at all. None of that is a separate feature to build later, it's what the dependency rule buys automatically once it's actually enforced.
+
+Nest the layers inside each bounded context, the way this post does, rather than reaching for four top-level folders that span the whole app, and the migration stops being a project. It becomes something you do to one module, `posts/domain.py` today, `auth/domain.py` next month, each one small enough to review on its own, each one leaving the app in a working state the moment it lands. Start with the module you already dread touching, extract the rule that keeps drifting between its three half-implementations, and give it exactly one home. The rest of this post is the map; the four sources below are where to go for the parts it only had room to summarize.
 
 ### Further Reading
 - [Domain-Driven Design: Tackling Complexity in the Heart of Software, Eric Evans (2003)](https://www.domainlanguage.com/ddd/)

--- a/content/domain-driven-design-architecture-that-grows-with-your-business.mdx
+++ b/content/domain-driven-design-architecture-that-grows-with-your-business.mdx
@@ -1,0 +1,221 @@
+---
+title: "Domain-Driven Design: Architecture That Grows with Your Business"
+description: Every FastAPI app starts with routers, schemas, services and repositories. Here's what breaks as the business grows, and how Domain-Driven Design's layers fix it without a rewrite.
+author: Igor Souza
+date: 2026-08-09
+published: true
+tags: ["python", "fastapi", "architecture", "ddd", "clean-architecture"]
+---
+Open any FastAPI project six months after the first commit and you'll usually find the same four folders: `routers/`, `schemas/`, `services/`, `repositories/`. It's the layout [zhanymkanov's fastapi-best-practices](https://github.com/zhanymkanov/fastapi-best-practices) popularized, and for good reason, it's simple, it's consistent, and it gets a small app shipped fast. Then the app grows, and something predictable happens: `services/post_service.py` starts importing `user_service.py`, which imports `notification_service.py`, and a "quick" change to how a post gets published means reading four files to find out which one actually owns the rule you're trying to change.
+
+This is the exact problem Domain-Driven Design was written to solve, just not the way most people first hear about it. You don't need aggregates, bounded contexts, or a whiteboard full of arrows to get real value out of it. You need one idea, applied consistently: **organize code around what the business does, not around the technical role each file plays.** This post is about turning that idea into folders you can actually build with FastAPI, starting from the structure you probably already have.
+
+## The layout everyone copies (and outgrows)
+
+The default shape looks something like this:
+
+```text
+app/
+├── routers/
+│   └── posts.py
+├── schemas/
+│   └── post.py
+├── services/
+│   └── post_service.py
+├── repositories/
+│   └── post_repository.py
+└── models/
+    └── post.py
+```
+
+Each folder answers "what kind of thing is this" from FastAPI's point of view: `routers/` handles HTTP, `schemas/` handles Pydantic validation, `services/` handles "logic," `repositories/` handles the database. That grouping is honest about the framework, but it's silent about the business. Nothing in that tree tells you what a "post" is allowed to do, what makes one valid, or what "publishing" actually means, that knowledge is scattered wherever it was convenient to write it at the time, usually inside `services/`, because that's the folder with the fewest rules about what belongs in it.
+
+<Callout icon="💡" type="informative">
+If this sounds familiar from a different framework, it should. Flask's blueprints exist to solve almost the same complaint, "everything is dumped in one place as the app grows", by letting you group routes by feature instead of by file type. Blueprints fix *where* code lives. They don't say anything about *which way the dependencies point*, which turns out to be the actual problem, as we'll get to shortly.
+</Callout>
+
+Left alone, this structure degrades in a specific, recognizable way: business rules leak into whichever layer happens to run first (usually the router, sometimes the Pydantic schema's `validator`), services accumulate cross-imports because nothing stops `PostService` from reaching into `UserService`'s internals, and "where does this rule live" stops having a one-file answer. None of this is a FastAPI problem, or even a Python problem. It's what happens to any codebase organized by technical role once the business logic outgrows a single file per role.
+
+## What "domain-driven" actually means
+
+Eric Evans named this problem in *Domain-Driven Design: Tackling Complexity in the Heart of Software* (2003), still the reference point everyone else, including this post, is building on. His core claim: complex software should be modeled around the business's own concepts and language, a "post" that gets "published," not around technical concerns like "the thing the router receives" or "the row the repository saves." When the code speaks the same words the business does, the two stay in sync; when it doesn't, every conversation with a domain expert needs translation, and the translation is where bugs hide.
+
+That's a way of thinking, not a folder structure. But folders are where a way of thinking either gets enforced or quietly abandoned under deadline pressure, so that's where we're going next: turning "organize around the business" into four directories with a clear job each.
+
+## Renaming what you already have
+
+Here's the useful part: three of your four existing folders already correspond to a real architectural layer, they're just missing a name and, more importantly, missing a rule about what they're *not* allowed to contain. This mapping, and the emphasis on keeping frameworks at the edges, is the same shape Robert C. Martin describes in *Clean Architecture* (2017) and that Harry Percival and Bob Gregory build a full Python example around in *Architecture Patterns with Python* (2020, free at [cosmicpython.com](https://www.cosmicpython.com/)):
+
+| Today | Layer | Job | Must **not** contain |
+|---|---|---|---|
+| `routers/` + `schemas/` | **Interface** | Translate HTTP requests into calls the app understands, and results back into HTTP responses | Business rules, validation beyond "is this JSON shaped right" |
+| `services/` | **Application** | Orchestrate a use case: fetch what's needed, ask the domain to do the work, save the result | Business rules, direct SQL/ORM calls |
+| `repositories/` + `models/` | **Infrastructure** | Concrete I/O: talk to Postgres, Redis, an external API | Business rules, decisions about *whether* something should happen |
+| *(nothing today)* | **Domain** | Entities, value objects, and the business rules that decide what's valid and what happens next | Any import of FastAPI, SQLAlchemy, or anything else framework-specific |
+
+The one genuinely new folder is `domain/`, and it's the one that matters most, because it's where the rule "a post needs a title and a body" or "a post can't be published twice" actually belongs. Not in a Pydantic validator, not in a service method, not in a database constraint discovered the hard way, in one file, named after the business concept it protects.
+
+<Callout icon="⚡" type="warning">
+Renaming `services/` to `application/` and calling it done is the most common way to fake this migration. If the folder still reaches into SQLAlchemy directly, or still decides business rules inline, you've relabeled the junk drawer, not fixed it. The names only earn their keep once the dependency rule below is actually true.
+</Callout>
+
+## The rule that actually matters: dependencies point inward
+
+Here's the part that's easy to skip and expensive to skip: **the domain layer must not depend on anything outside it.** No FastAPI imports, no SQLAlchemy imports, nothing. It defines *what it needs* as an interface (a `Protocol` or `ABC` in Python), and everything else depends on *it*, not the other way round.
+
+```text
+   interface  ──depends on──▶  application  ──depends on──▶  domain
+                                                                 ▲
+                                                                 │
+                              infrastructure ───implements───────┘
+```
+
+This is Martin's dependency rule from *Clean Architecture*, stripped to the one sentence worth remembering: **frameworks and databases are details, and details should depend on policy, not the other way around.** The domain layer is the policy. FastAPI and Postgres are details, replaceable ones, if the arrows point the right way.
+
+The payoff isn't aesthetic. If `PublishPost` (application) depends on `PostRepository` (an interface the domain defines) rather than on `SqlPostRepository` (a concrete infrastructure class), you can hand it an in-memory fake in a test and exercise every business rule without a database, a running FastAPI app, or a mock library in sight. That's the actual reason to do any of this: not tidier folders, but business logic you can test and change without dragging the rest of the stack along.
+
+## Worked example: publishing a post
+
+Same use case, both layouts, so the difference is concrete instead of abstract.
+
+**Default layout.** The validation rule about what makes a post valid lives inside `PostService`, which is nominally "just orchestration":
+
+```python {5,6,7} showLineNumbers
+# services/post_service.py
+class PostService:
+    def __init__(self, repo: PostRepository):
+        self.repo = repo
+
+    def publish(self, data: PostCreate) -> dict:
+        if not data.title or not data.body:
+            raise ValueError("title and body required")
+        if len(data.title) > 99:
+            raise ValueError("title too long")
+        post = {"title": data.title, "body": data.body, "published": True}
+        return self.repo.save(post)
+```
+
+Nothing here is wrong, exactly, but notice the rule "a post needs a title and a body under 99 characters" only exists because someone remembered to write it in this one method. Call `PostService.publish` from a CLI script or a Celery task instead of the router, and you'd better hope whoever wrote that code copied the same checks.
+
+**DDD layout.** The same rule moves into the one place that owns it:
+
+```python {6,7,8,9} showLineNumbers
+# domain/post.py
+from dataclasses import dataclass
+from typing import Protocol
+
+@dataclass
+class Post:
+    title: str
+    body: str
+    published: bool = False
+
+    def __post_init__(self):
+        if not self.title or not self.body:
+            raise ValueError("a post needs a title and a body")
+        if len(self.title) > 99:
+            raise ValueError("title too long")
+
+    def publish(self) -> None:
+        self.published = True
+
+class PostRepository(Protocol):
+    def save(self, post: Post) -> Post: ...
+```
+
+```python showLineNumbers
+# application/publish_post.py
+from dataclasses import dataclass
+from domain.post import Post, PostRepository
+
+@dataclass
+class PublishPost:
+    repository: PostRepository
+
+    def execute(self, title: str, body: str) -> Post:
+        post = Post(title=title, body=body)
+        post.publish()
+        return self.repository.save(post)
+```
+
+```python showLineNumbers
+# infrastructure/sql_post_repository.py
+from domain.post import Post
+
+class SqlPostRepository:  # implements PostRepository, no base class required
+    def __init__(self, session):
+        self.session = session
+
+    def save(self, post: Post) -> Post:
+        row = PostModel(title=post.title, body=post.body, published=post.published)
+        self.session.add(row)
+        self.session.commit()
+        return post
+```
+
+```python showLineNumbers
+# interface/routers/posts.py
+from fastapi import APIRouter, Depends
+from application.publish_post import PublishPost
+
+router = APIRouter()
+
+@router.post("/posts")
+def publish_post(data: PostCreate, use_case: PublishPost = Depends(get_publish_post_use_case)):
+    post = use_case.execute(title=data.title, body=data.body)
+    return PostOut.from_domain(post)
+```
+
+`Post` doesn't know FastAPI exists. `PublishPost` doesn't know whether `PostRepository` is backed by Postgres, SQLite, or a dictionary in a test, it depends on the `Protocol`, not on `SqlPostRepository`. That last point is what makes the test for this use case genuinely simple:
+
+```python showLineNumbers
+class FakePostRepository:
+    def __init__(self):
+        self.saved = []
+
+    def save(self, post):
+        self.saved.append(post)
+        return post
+
+def test_publish_post_marks_it_published():
+    use_case = PublishPost(repository=FakePostRepository())
+    post = use_case.execute(title="Hello", body="World")
+    assert post.published is True
+```
+
+No database, no FastAPI `TestClient`, no mocking framework, just the business rule, isolated and fast to run. That's the concrete version of "ports and adapters" that Percival and Gregory build their entire book around: the domain defines the port (`PostRepository`), infrastructure supplies the adapter (`SqlPostRepository`), and swapping the adapter never touches the port or the business logic behind it.
+
+## Don't cargo-cult it
+
+None of this is free. Four layers instead of two is more files, more indirection, and more places to look up a definition, and that cost is only worth paying once the domain has enough real rules to protect. Percival and Gregory are explicit about this in *Architecture Patterns with Python*: start simple, and grow into ports, entities, and a real domain layer only once complexity actually demands it.
+
+<Callout icon="⚡" type="danger">
+If your "service" layer is entirely `def get(self, id): return self.repo.get(id)`, you don't have a missing domain layer, you have a CRUD app, and a CRUD app doesn't need one. Adding `domain/` and `application/` folders to a project with no real business rules just adds ceremony around code that was never going to change independently anyway.
+</Callout>
+
+The tell that you've earned this structure isn't the size of the codebase, it's the shape of the bugs you're getting: rules duplicated in two places and drifting apart, a router doing three unrelated things because "that's where the request comes in," or a test suite that can't exercise business logic without spinning up a real database. When those show up, the layers pay for themselves. Before that, they're just overhead.
+
+## Bringing it into an existing app, one slice at a time
+
+You don't need a rewrite to get here, and attempting one is how these migrations stall out. Instead, pick the single most tangled service, the one you dread changing, and work through it in order:
+
+1. **Extract the validation and business rules** out of that service into a small dataclass or class under `domain/`, the way `Post.__post_init__` does above.
+2. **Define a `Protocol`** for whatever that service persists or fetches, owned by the domain, describing only what the business logic actually needs.
+3. **Point the existing repository at that `Protocol`** implicitly, Python's structural typing means an existing class that already has a matching `save` method satisfies it with zero changes.
+4. **Thin the service down** into an application-layer use case that only orchestrates: call the domain, call the repository, done.
+5. **Leave the router and schema alone.** They're already close to the interface layer's job; they don't need to move on day one.
+6. **Repeat per feature**, not per file. A `domain/post.py` next to an untouched `services/user_service.py` is a valid, working intermediate state, not a mess to apologize for.
+
+Each step is small enough to review on its own, and the app runs correctly after every single one of them, which is the actual point: architecture is something you grow into, the same way the business itself grows, not something you stop and rebuild for.
+
+## Conclusion
+
+None of the four layers here are new ideas, `routers/`, `schemas/`, `services/`, and `repositories/` were already most of the way there. What was missing was a name for the business rules that didn't fit anywhere, and a rule about which direction the imports are allowed to point. Get the direction right, domain depending on nothing, everything else depending on domain, and the rest, testability, a home for logic that doesn't belong to any one endpoint, the ability to swap Postgres for something else without touching a business rule, follows from that one decision almost automatically.
+
+Start from the structure you already have. Rename nothing until the dependency direction actually changes underneath it.
+
+### Further Reading
+- [Domain-Driven Design: Tackling Complexity in the Heart of Software, Eric Evans (2003)](https://www.domainlanguage.com/ddd/)
+- [Clean Architecture, Robert C. Martin (2017)](https://www.oreilly.com/library/view/clean-architecture-a/9780134494272/)
+- [Architecture Patterns with Python, Harry Percival & Bob Gregory — free online](https://www.cosmicpython.com/)
+- [FastAPI Best Practices, zhanymkanov](https://github.com/zhanymkanov/fastapi-best-practices)

--- a/content/domain-driven-design-architecture-that-grows-with-your-business.mdx
+++ b/content/domain-driven-design-architecture-that-grows-with-your-business.mdx
@@ -142,7 +142,7 @@ Finally, `domain/` also owns the repository `Protocol`s, `PostRepository`, `Comm
 
 `router.py` and `schemas.py` are Evans' User Interface layer, under a name that fits an API with no actual UI. `schemas.py` defines the shape of requests and responses, and it's deliberately allowed to differ from the domain's own shape, a `PostCreate` schema has no `id` field, because the client isn't supposed to invent one, while the `Post` entity always has one once it exists. `router.py` wires an HTTP verb and path to a use case via FastAPI's `Depends`, converts the incoming schema into whatever primitive arguments that use case actually takes, and converts its return value back into a response schema. Nothing in this layer decides anything; it translates in both directions and gets out of the way.
 
-Percival and Gregory's own example application in *Architecture Patterns with Python* puts these same four layers at the top level instead, `domain/`, `service_layer/`, `adapters/`, spanning the whole app. That reads naturally in their book because it only ever deals with one bounded context. The moment an app has more than one, `posts` and `auth` and `aws` all needing their own domain rules, nesting the layers inside each context keeps them separate the way Evans intended, instead of merging every context's entities into one shared `domain/` folder.
+Percival and Gregory's own example application in *Architecture Patterns with Python* puts these same four layers at the top level instead, `domain/`, `service_layer/`, `adapters/`, `entrypoints/`, spanning the whole app. That reads naturally in their book because it only ever deals with one bounded context. The moment an app has more than one, `posts` and `auth` and `aws` all needing their own domain rules, nesting the layers inside each context keeps them separate the way Evans intended, instead of merging every context's entities into one shared `domain/` folder.
 
 ## Worked example: publishing a post
 
@@ -150,7 +150,7 @@ Same use case, both layouts, so the difference is concrete instead of abstract. 
 
 **Default layout.** The validation rule about what makes a post valid lives inside `PostService`, which is nominally "just orchestration":
 
-```python {5,6,7} showLineNumbers
+```python {6,7,8,9,10} showLineNumbers
 # posts/service.py
 class PostService:
     def __init__(self, repo: PostRepository):
@@ -169,7 +169,7 @@ Nothing here is wrong, exactly, but the rule "a post needs a title and a body un
 
 **DDD layout.** The same rule moves into the one place that owns it:
 
-```python {6,7,8,9} showLineNumbers
+```python {11,12,13,14,15} showLineNumbers
 # posts/domain.py
 from dataclasses import dataclass
 from typing import Protocol
@@ -283,7 +283,7 @@ Each step is small enough to review on its own, and the app runs correctly after
 
 ## Conclusion
 
-`router.py`, `schemas.py`, `service.py`, and `models.py`, grouped by bounded context, were already most of the way to the layered architecture Evans described in 2003, before Clean Architecture had a name and before cosmicpython existed to demonstrate it in Python. What was actually missing was two things, not one: a name for the business rules that didn't fit anywhere, `domain.py`, and a rule about which direction the imports are allowed to point, domain depending on nothing, everything else depending on domain. Neither shows up by accident. A `domain.py` file that still gets imported by `infrastructure.py`, or a `Post` entity that still imports `sqlalchemy`, has the right filename in the wrong place, and none of the payoff below follows from a filename alone.
+`router.py`, `schemas.py`, `service.py`, and `models.py`, grouped by bounded context, were already most of the way to the layered architecture Evans described in 2003, before Clean Architecture had a name and before cosmicpython existed to demonstrate it in Python. What was actually missing was two things, not one: a name for the business rules that didn't fit anywhere, `domain.py`, and a rule about which direction the imports are allowed to point, domain depending on nothing, everything else depending on domain. Neither shows up by accident. A `domain.py` file that still imports `infrastructure.py`, or a `Post` entity that still imports `sqlalchemy`, has the right filename in the wrong place, and none of the payoff below follows from a filename alone.
 
 Get both things right and the rest stops being separate work: testability, because a use case built against a `Protocol` accepts a fake repository in a test without a database in sight; a single home for logic that doesn't belong to any one endpoint, so a CLI command and an HTTP route can call the same `PublishPost` use case instead of reimplementing "what makes a post valid" twice; the ability to swap Postgres for something else, or add a second, differently-backed implementation of the same repository, without touching a business rule at all. None of that is a separate feature to build later, it's what the dependency rule buys automatically once it's actually enforced.
 

--- a/content/domain-driven-design-architecture-that-grows-with-your-business.mdx
+++ b/content/domain-driven-design-architecture-that-grows-with-your-business.mdx
@@ -1,14 +1,18 @@
 ---
 title: "Domain-Driven Design: Architecture That Grows with Your Business"
-description: fastapi-best-practices already groups code by feature. Here's the gap that's left, the two ways Domain-Driven Design closes it, and how to pick between them.
+description: Business rules that scatter across routers, schemas and models are a domain problem, not a FastAPI one. Here's how Domain-Driven Design fixes it, in two flavors, and how to choose between them.
 author: Igor Souza
 date: 2026-08-09
 published: true
 tags: ["python", "fastapi", "architecture", "ddd", "clean-architecture"]
 ---
-Open the file tree in [zhanymkanov's fastapi-best-practices](https://github.com/zhanymkanov/fastapi-best-practices), by far the most-copied FastAPI structure out there, and you won't find one global `routers/` folder holding every endpoint in the app. You'll find this:
+Every FastAPI project I've built starts the same way: a `posts` folder, a router, a couple of Pydantic schemas, a service function, a database model. It works cleanly for weeks. Then one day I need to change a single rule, say a post shouldn't be publishable without a body, and I can't find the one place that rule actually lives. It's half-written in a Pydantic validator, half-assumed by the router, and the database has its own opinion via a `NOT NULL` constraint. Three sources of truth for one sentence of business logic, and no way to change it without touching all three.
 
-## The layout everyone actually copies
+That's not really a FastAPI problem. It's what happens to any growing application that never gave its business rules a home of their own. Domain-Driven Design, the term Eric Evans coined in *Domain-Driven Design: Tackling Complexity in the Heart of Software* (2003), is the name for fixing exactly that: organizing code around what the business does, a post, publishing, instead of around whatever technical layer happens to run first. The idea itself doesn't tell you which folder anything belongs in, so this post is about two well-known sources that turn it into an actual FastAPI project layout, and how to pick between them.
+
+## fastapi-best-practices already gets you halfway
+
+[zhanymkanov's fastapi-best-practices](https://github.com/zhanymkanov/fastapi-best-practices), probably the most-copied FastAPI layout there is, already groups files by feature instead of by technical role:
 
 ```text
 src
@@ -37,27 +41,11 @@ src
 └── main.py
 ```
 
-Each feature gets its own module, `auth`, `posts`, `aws`, and every module carries its own router, schemas, models and service together. That's already a meaningful step in the direction this post is going: code is grouped by what the business does, `auth`, `posts`, not by technical role. It's the same move Flask's blueprints make, group routes by feature instead of dumping them all in one file, and the fastapi-best-practices guide leads with it as its very first recommendation.
+That's a good instinct: code about "posts" lives together, instead of one `routers/` folder holding every endpoint in the app regardless of what it's for. It's the same move Flask's blueprints make, grouping by feature instead of by file type, and fastapi-best-practices leads with it as its very first recommendation. What it doesn't do is separate the business rule from the file that happens to run it. `service.py` ends up holding validation, orchestration, and the call down into the database all at once, so a rule like "a post needs a title and a body" still has no single home, it's just contained to one folder instead of scattered across the whole app.
 
-<Callout icon="💡" type="informative">
-Worth being precise here, since this repo gets cited, and misquoted, constantly: it does **not** recommend one giant `routers/` package for the whole app. That flatter, everything-grouped-by-technical-role layout is a pattern teams sometimes drift into on their own, often while half-remembering this exact guide, not what it actually says. If anything, the real recommendation is already halfway to where this post is headed.
-</Callout>
+## Turning that into four layers
 
-So where's the crack, if the top level is already this reasonable? Inside each module. Open `posts/service.py` six months into a growing app and it's usually carrying three unrelated jobs at once: deciding what makes a post valid, deciding what "publishing" means, and orchestrating the call down into `posts/models.py`'s ORM layer. None of those three jobs is wrong to have. Bundling all three into one file with no name for the difference between them is the problem, and it's the same problem a flat, technical-role-first structure has, just contained to a smaller blast radius. There's still no single place that answers "what is a valid Post," independent of whether the caller is `posts/router.py`, a Celery task, or a test.
-
-<Callout icon="⚡" type="warning">
-Grouping by feature (what `auth/`, `posts/`, and Flask blueprints all do) answers *where* code for a feature lives. It says nothing about *which way the dependencies inside that feature should point*, or which file owns a business rule versus which one just orchestrates it. That gap, not the folder layout, is what Domain-Driven Design's layering actually closes.
-</Callout>
-
-## What "domain-driven" actually means
-
-Eric Evans named this problem in *Domain-Driven Design: Tackling Complexity in the Heart of Software* (2003), still the reference point everyone else, including this post, is building on. His core claim: complex software should be modeled around the business's own concepts and language, a "post" that gets "published," not around technical concerns like "the thing the router receives" or "the row the repository saves." When the code speaks the same words the business does, the two stay in sync; when it doesn't, every conversation with a domain expert needs translation, and the translation is where bugs hide.
-
-That's a way of thinking, not a folder structure. But folders are where a way of thinking either gets enforced or quietly abandoned under deadline pressure, so that's where we're going next: turning "organize around the business" into four directories with a clear job each.
-
-## Renaming what you already have
-
-Here's the useful part: three of the four files already inside each module correspond to a real architectural layer, they're just missing a name and, more importantly, missing a rule about what they're *not* allowed to contain. This mapping, and the emphasis on keeping frameworks at the edges, is the same shape Robert C. Martin describes in *Clean Architecture* (2017) and that Harry Percival and Bob Gregory build a full Python example around in *Architecture Patterns with Python* (2020, free at [cosmicpython.com](https://www.cosmicpython.com/)):
+This is where the more classic DDD sources pick up: Robert C. Martin's *Clean Architecture* (2017), and Harry Percival and Bob Gregory's *Architecture Patterns with Python* (2020, free at [cosmicpython.com](https://www.cosmicpython.com/)), which builds a full Python example around the same ideas. Both describe the same four responsibilities, and each file already inside a fastapi-best-practices module maps onto one of them:
 
 | Inside `posts/` today | Layer | Job | Must **not** contain |
 |---|---|---|---|
@@ -66,15 +54,11 @@ Here's the useful part: three of the four files already inside each module corre
 | `models.py` | **Infrastructure** | Concrete I/O: talk to Postgres, Redis, an external API | Business rules, decisions about *whether* something should happen |
 | *(nothing today)* | **Domain** | Entities, value objects, and the business rules that decide what's valid and what happens next | Any import of FastAPI, SQLAlchemy, or anything else framework-specific |
 
-The one genuinely new file is `domain.py`, and it's the one that matters most, because it's where the rule "a post needs a title and a body" or "a post can't be published twice" actually belongs. Not in a Pydantic validator, not in a service method, not in a database constraint discovered the hard way, in one file, named after the business concept it protects. Notice this split happens **inside each module**, `auth/domain.py` sitting next to `posts/domain.py`, not as four new folders cutting across the whole app. That keeps the change scoped to one feature at a time, and it echoes Evans' own idea of a bounded context: each feature gets to define its rules independently of the others.
-
-<Callout icon="⚡" type="warning">
-Renaming `service.py` to `application.py` and calling it done is the most common way to fake this migration. If the file still reaches into SQLAlchemy directly, or still decides business rules inline, you've relabeled the junk drawer, not fixed it. The names only earn their keep once the dependency rule below is actually true.
-</Callout>
+The one genuinely new file is `domain.py`, and it's the one that matters most: it's where "a post needs a title and a body" actually belongs, in one place, named after the business concept it protects, instead of split across a validator, a service method, and a database constraint. This split happens **inside each module**, `auth/domain.py` sitting next to `posts/domain.py`, which keeps the change scoped to one feature at a time and echoes Evans' own idea of a bounded context: each feature gets to define its rules independently of the others.
 
 ## The rule that actually matters: dependencies point inward
 
-Here's the part that's easy to skip and expensive to skip: **the domain layer must not depend on anything outside it.** No FastAPI imports, no SQLAlchemy imports, nothing. It defines *what it needs* as an interface (a `Protocol` or `ABC` in Python), and everything else depends on *it*, not the other way round.
+The domain layer must not depend on anything outside it. No FastAPI imports, no SQLAlchemy imports, nothing. It defines *what it needs* as an interface (a `Protocol` or `ABC` in Python), and everything else depends on *it*, not the other way round:
 
 ```text
    interface  ──depends on──▶  application  ──depends on──▶  domain
@@ -83,15 +67,15 @@ Here's the part that's easy to skip and expensive to skip: **the domain layer mu
                               infrastructure ───implements───────┘
 ```
 
-This is Martin's dependency rule from *Clean Architecture*, stripped to the one sentence worth remembering: **frameworks and databases are details, and details should depend on policy, not the other way around.** The domain layer is the policy. FastAPI and Postgres are details, replaceable ones, if the arrows point the right way. And this exact diagram repeats once per module: `auth/router.py → auth/service.py → auth/domain.py`, `posts/router.py → posts/service.py → posts/domain.py`, and so on, each feature enforcing its own boundary independently.
+This is Martin's dependency rule, stripped to one sentence: **frameworks and databases are details, and details should depend on policy, not the other way around.** The domain layer is the policy; FastAPI and Postgres are details, replaceable ones, if the arrows point the right way. The diagram repeats once per module, `auth/router.py → auth/service.py → auth/domain.py`, `posts/router.py → posts/service.py → posts/domain.py`, each feature enforcing its own boundary independently.
 
-The payoff isn't aesthetic. If `PublishPost` (application) depends on `PostRepository` (an interface the domain defines) rather than on `SqlPostRepository` (a concrete infrastructure class), you can hand it an in-memory fake in a test and exercise every business rule without a database, a running FastAPI app, or a mock library in sight. That's the actual reason to do any of this: not tidier folders, but business logic you can test and change without dragging the rest of the stack along.
+The payoff isn't aesthetic. If a `PublishPost` use case depends on a `PostRepository` interface the domain defines, rather than on a concrete `SqlPostRepository`, you can hand it an in-memory fake in a test and exercise every business rule without a database, a running FastAPI app, or a mock library in sight. That's the actual reason to do any of this: not tidier folders, but business logic you can test and change without dragging the rest of the stack along.
 
 ## Two ways to arrange the layers
 
-Everything above tells you *what* the four layers are, but not *where the folder boundaries go*, and that turns out to have two reasonable answers. Which one to pick is a real decision, not just taste, so here's both, plus how to choose.
+Knowing the four layers still leaves one open question: where do the folder boundaries actually go? The two sources above answer it differently, and both answers are legitimate.
 
-**Feature-first (nest the layers inside each module).** Keep `auth/`, `posts/`, `aws/` exactly as fastapi-best-practices ships them, and add one new file per module:
+**Feature-first, following fastapi-best-practices.** Keep `auth/`, `posts/`, `aws/` exactly as they ship, and add one new file per module:
 
 ```text
 posts
@@ -102,9 +86,9 @@ posts
 └── models.py       # infrastructure
 ```
 
-This is the smallest possible diff from what you already have, everything about "posts" still lives in one folder, and it's what the worked example below uses.
+This is the smallest possible diff from what you already have; everything about "posts" still lives in one folder. It's what the worked example below uses.
 
-**Layer-first (the textbook Clean Architecture / hexagonal shape).** Flip the axis: layers become the top-level folders, and each one holds one file per feature. This is close to how Percival and Gregory actually lay out their own example application in *Architecture Patterns with Python* (`domain/`, `service_layer/`, `adapters/`):
+**Layer-first, following Clean Architecture / Percival and Gregory more literally.** Flip the axis: layers become the top-level folders, each one holding one file per feature, close to how *Architecture Patterns with Python*'s own example app is laid out (`domain/`, `service_layer/`, `adapters/`):
 
 ```text
 src
@@ -122,7 +106,7 @@ src
     └── auth_router.py
 ```
 
-Same four responsibilities, same dependency direction, just organized as columns instead of nested inside each feature folder.
+Same four responsibilities, same dependency direction, organized as columns instead of nested inside each feature folder.
 
 | | Feature-first | Layer-first |
 |---|---|---|
@@ -131,11 +115,11 @@ Same four responsibilities, same dependency direction, just organized as columns
 | Enforcing "domain imports nothing" | Code review, or a per-module lint rule | One `import-linter`/Deptrac rule for the whole codebase |
 | Best fit | Small-to-medium team, each feature has one entry point (its own REST routes) | Domain shared across several entry points (HTTP + CLI + worker), or a team that wants the boundary machine-checked, not just reviewed |
 
-Neither is "more correct" DDD, Evans never mandated a folder layout, Martin's circles are a diagram, not a directory listing. Start feature-first if you're evolving an existing fastapi-best-practices app, which covers most real migrations; reach for layer-first when the domain layer has outgrown a single HTTP-shaped module or you want CI, not a reviewer, catching a stray `import sqlalchemy` inside `domain/`.
+Neither is "more correct" DDD, Evans never mandated a folder layout, Martin's circles are a diagram, not a directory listing. Feature-first is the better starting point for evolving an existing fastapi-best-practices app, which covers most real migrations. Layer-first earns its cost once the domain layer has outgrown a single HTTP-shaped module, or once a team wants CI, not a reviewer, catching a stray `import sqlalchemy` inside `domain/`.
 
 ## Worked example: publishing a post
 
-Same use case, both layouts, so the difference is concrete instead of abstract. This uses the feature-first arrangement from above, since it's the smaller step from what you already have.
+Same use case, both layouts, so the difference is concrete instead of abstract. This uses the feature-first arrangement, since it's the smaller step from what you already have.
 
 **Default layout.** The validation rule about what makes a post valid lives inside `PostService`, which is nominally "just orchestration":
 
@@ -154,7 +138,7 @@ class PostService:
         return self.repo.save(post)
 ```
 
-Nothing here is wrong, exactly, but notice the rule "a post needs a title and a body under 99 characters" only exists because someone remembered to write it in this one method. Call `PostService.publish` from a CLI script or a Celery task instead of the router, and you'd better hope whoever wrote that code copied the same checks.
+Nothing here is wrong, exactly, but the rule "a post needs a title and a body under 99 characters" only exists because someone remembered to write it in this one method. Call `PostService.publish` from a CLI script or a Celery task instead of the router, and you'd better hope whoever wrote that code copied the same checks.
 
 **DDD layout.** The same rule moves into the one place that owns it:
 
@@ -242,36 +226,36 @@ def test_publish_post_marks_it_published():
     assert post.published is True
 ```
 
-No database, no FastAPI `TestClient`, no mocking framework, just the business rule, isolated and fast to run. That's the concrete version of "ports and adapters" that Percival and Gregory build their entire book around: the domain defines the port (`PostRepository`), infrastructure supplies the adapter (`SqlPostRepository`), and swapping the adapter never touches the port or the business logic behind it. Had this used the layer-first arrangement instead, the classes above wouldn't change at all, only their addresses would: `posts/domain.py` becomes `domain/posts.py`, `posts/application.py` becomes `application/publish_post.py`, and so on. The behavior, and the test, are identical either way, which is the point: the folder axis is a navigation choice, the dependency direction is the architecture.
+No database, no FastAPI `TestClient`, no mocking framework, just the business rule, isolated and fast to run. That's the concrete version of "ports and adapters" Percival and Gregory build their entire book around: the domain defines the port (`PostRepository`), infrastructure supplies the adapter (`SqlPostRepository`), and swapping the adapter never touches the port or the business logic behind it. Had this used the layer-first arrangement instead, the classes wouldn't change at all, only their addresses would: `posts/domain.py` becomes `domain/posts.py`, `posts/application.py` becomes `application/publish_post.py`, and so on. The behavior, and the test, are identical either way, the folder axis is a navigation choice, the dependency direction is the architecture.
 
-## Don't cargo-cult it
+## Where this goes wrong
 
-None of this is free. Four layers instead of two is more files, more indirection, and more places to look up a definition, and that cost is only worth paying once the domain has enough real rules to protect. Percival and Gregory are explicit about this in *Architecture Patterns with Python*: start simple, and grow into ports, entities, and a real domain layer only once complexity actually demands it.
+Four layers instead of two is more files, more indirection, and more places to look up a definition, and that cost is only worth paying once the domain has enough real rules to protect. Percival and Gregory are explicit about this: start simple, and grow into ports, entities, and a real domain layer only once complexity actually demands it.
 
 <Callout icon="⚡" type="danger">
-If `posts/service.py` is entirely `def get(self, id): return self.repo.get(id)`, you don't have a missing domain layer, you have a CRUD app, and a CRUD app doesn't need one, feature-first or layer-first. Adding a `domain.py` (or a whole `domain/` folder) to a module with no real business rules just adds ceremony around code that was never going to change independently anyway.
+If `posts/service.py` is entirely `def get(self, id): return self.repo.get(id)`, that's not a missing domain layer, that's a CRUD app, and a CRUD app doesn't need one, feature-first or layer-first. Adding a `domain.py` to a module with no real business rules just adds ceremony around code that was never going to change independently anyway.
 </Callout>
+
+The other common failure is doing the rename without doing the work: calling `service.py` `application.py` while it still reaches into SQLAlchemy directly, or still decides business rules inline. That relabels the junk drawer, it doesn't fix it, the names only earn their keep once the dependency rule actually holds.
 
 The tell that you've earned this structure isn't the size of the codebase, it's the shape of the bugs you're getting: rules duplicated in two places and drifting apart, a router doing three unrelated things because "that's where the request comes in," or a test suite that can't exercise business logic without spinning up a real database. When those show up, the layers pay for themselves. Before that, they're just overhead.
 
 ## Bringing it into an existing app, one slice at a time
 
-You don't need a rewrite to get here, and attempting one is how these migrations stall out. The feature-first version, in particular, is designed to be added incrementally: pick the single most tangled `service.py`, the one you dread changing, and work through it in order:
+You don't need a rewrite to get here, attempting one is how these migrations stall out. The feature-first version is built to be added incrementally: pick the single most tangled `service.py`, the one you dread changing, and work through it in order.
 
 1. **Extract the validation and business rules** out of `service.py` into a small dataclass or class in a new `domain.py` next to it, the way `Post.__post_init__` does above.
 2. **Define a `Protocol`** for whatever that module persists or fetches, owned by `domain.py`, describing only what the business logic actually needs.
 3. **Point the existing `models.py` at that `Protocol`** implicitly, Python's structural typing means an existing class that already has a matching `save` method satisfies it with zero changes.
 4. **Thin `service.py` down** into an application-layer use case that only orchestrates: call the domain, call the repository, done. Renaming the file to `application.py` is optional, and can wait.
-5. **Leave `router.py` and `schemas.py` alone.** They're already exactly where the interface layer belongs; they don't need to move on day one.
-6. **Repeat per module**, not per file, and not all at once. A `posts/domain.py` next to an untouched `auth/service.py` is a valid, working intermediate state, not a mess to apologize for.
+5. **Leave `router.py` and `schemas.py` alone.** They're already exactly where the interface layer belongs.
+6. **Repeat per module**, not per file, and not all at once. A `posts/domain.py` next to an untouched `auth/service.py` is a valid, working intermediate state.
 
-Each step is small enough to review on its own, and the app runs correctly after every single one of them, which is the actual point: architecture is something you grow into, the same way the business itself grows, not something you stop and rebuild for. Moving to layer-first later, if you ever need to, is a bigger, more deliberate jump, plan it as its own piece of work rather than smuggling it into an unrelated feature change.
+Each step is small enough to review on its own, and the app runs correctly after every single one of them, which is the actual point: architecture is something you grow into, the same way the business itself grows. Moving to layer-first later, if the domain ever outgrows a single module, is a bigger, more deliberate jump worth planning as its own piece of work, rather than folding it into an unrelated feature change.
 
 ## Conclusion
 
-None of the four layers here are new ideas, `router.py`, `schemas.py`, `service.py`, and `models.py`, grouped by feature, were already most of the way there. What was missing was a name for the business rules that didn't fit anywhere, and a rule about which direction the imports are allowed to point. Get the direction right, domain depending on nothing, everything else depending on domain, and the rest, testability, a home for logic that doesn't belong to any one endpoint, the ability to swap Postgres for something else without touching a business rule, follows from that one decision almost automatically. Whether you enforce it by nesting the layers inside each feature or by making them the top-level folders is a real choice, but it's a secondary one.
-
-Start from the structure you already have. Rename nothing until the dependency direction actually changes underneath it.
+`router.py`, `schemas.py`, `service.py`, and `models.py`, grouped by feature, were already most of the way to a domain-driven structure. What was missing was a name for the business rules that didn't fit anywhere, and a rule about which direction the imports are allowed to point. Get the direction right, domain depending on nothing, everything else depending on domain, and the rest, testability, a home for logic that doesn't belong to any one endpoint, the ability to swap Postgres for something else without touching a business rule, follows from that decision almost automatically. Whether you enforce it by nesting the layers inside each feature or by making them the top-level folders is a real choice, but a secondary one, made once the first one, giving the business rules a home at all, is settled.
 
 ### Further Reading
 - [Domain-Driven Design: Tackling Complexity in the Heart of Software, Eric Evans (2003)](https://www.domainlanguage.com/ddd/)

--- a/e2e/post-navigation.spec.ts
+++ b/e2e/post-navigation.spec.ts
@@ -6,7 +6,8 @@ import { test, expect } from "@playwright/test";
 // suite.
 const OLDEST_POST = "welcome";
 const MIDDLE_POST = "we-need-to-talk-about-gil";
-const NEWEST_POST = "async-vs-threading-the-battle-for-supremacy";
+const NEWEST_POST =
+  "domain-driven-design-architecture-that-grows-with-your-business";
 
 test.describe("Post navigation", () => {
   test("middle post shows both previous and next links", async ({ page }) => {


### PR DESCRIPTION
## Summary

Adds a new article on Domain-Driven Design architecture patterns for FastAPI applications, explaining how to evolve from the standard `routers/schemas/services/repositories` structure into a layered architecture with clear separation of concerns.

## Changes

- **New article:** `content/domain-driven-design-architecture-that-grows-with-your-business.mdx`
  - Explains the limitations of the default FastAPI project structure
  - Introduces the four-layer architecture (Interface, Application, Domain, Infrastructure)
  - Demonstrates the dependency rule: frameworks and databases depend on domain logic, not vice versa
  - Provides a worked example comparing the default layout vs. DDD layout for a "publish post" use case
  - Includes practical guidance on incremental migration and when to apply these patterns
  - References foundational works (Evans, Martin, Percival & Gregory)

- **Test update:** `e2e/post-navigation.spec.ts`
  - Updates `NEWEST_POST` constant to reflect the new article as the most recent post

## Implementation Notes

The article follows the site's existing conventions:
- Frontmatter with title, description, author, date, published flag, and tags
- Markdown with code examples (Python), callout components, and a further reading section
- Practical focus on applying DDD incrementally to existing FastAPI projects rather than as a complete rewrite

https://claude.ai/code/session_019z82FRek95XnbnBBDhXa1c