### PR TITLE
Add print stylesheet for blog posts

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -86,3 +86,75 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Print styles (issue #42): force an ink-safe light theme regardless of
+   the active dark/light theme. Site chrome (header, footer, scroll
+   progress, post navigation) is hidden with Tailwind's `print:hidden`
+   utility in the components themselves. */
+
+@page {
+  margin: 1.5cm;
+}
+
+@media print {
+  /* Force light-theme design tokens even when `.dark` is set on
+     html/body, so printing while in dark mode yields light output. */
+  :root,
+  .dark {
+    --background: 0 0% 100%;
+    --foreground: 240 10% 3.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 240 10% 3.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 240 10% 3.9%;
+    --primary: 240 5.9% 10%;
+    --primary-foreground: 0 0% 98%;
+    --secondary: 240 4.8% 95.9%;
+    --secondary-foreground: 240 5.9% 10%;
+    --muted: 240 4.8% 95.9%;
+    --muted-foreground: 240 3.8% 46.1%;
+    --accent: 240 4.8% 95.9%;
+    --accent-foreground: 240 5.9% 10%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 240 5.9% 90%;
+    --input: 240 5.9% 90%;
+    --ring: 240 10% 3.9%;
+  }
+
+  html,
+  body {
+    background: #fff !important;
+    color: #000 !important;
+  }
+
+  /* Ink-safe article body: black text, no dark backgrounds, no shadows.
+     !important is required to beat the inline style="color: ..." spans
+     emitted by rehype-pretty-code (shiki github-dark theme), the
+     bg-black utility on <pre>, and dark:prose-invert. */
+  article,
+  article * {
+    color: #000 !important;
+    background-color: transparent !important;
+    text-shadow: none !important;
+    box-shadow: none !important;
+  }
+
+  /* Inline links print as plain underlined black text, no URL dump. */
+  article a {
+    text-decoration: underline;
+  }
+
+  /* Sensible pagination behavior. */
+  h1, h2, h3, h4, h5, h6 {
+    break-after: avoid;
+  }
+  pre, blockquote, figure, img {
+    break-inside: avoid;
+  }
+  /* On screen long code lines scroll horizontally; on paper they must wrap. */
+  pre {
+    white-space: pre-wrap !important;
+    word-break: break-word;
+  }
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -5,7 +5,7 @@ import { personalInfo } from "@/lib/utils";
 
 export default function Footer() {
   return (
-    <footer className="py-6 lg:py-10">
+    <footer className="py-6 lg:py-10 print:hidden">
       <hr className="my-5"/>
       <div className="flex flex-col sm:flex-row justify-between gap-8 items-center text-muted-foreground">
         <ul className="flex flex-col items-center gap-2 px-4">

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 
 export default function Header(){
   return (
-    <header className="py-6 lg:py-10">
+    <header className="py-6 lg:py-10 print:hidden">
       <div className="flex gap-4 flex-row justify-between md:gap-8">
         <Link className="hidden sm:inline-block" href="/">
           <Logo size={36}/>

--- a/components/post-navigation.tsx
+++ b/components/post-navigation.tsx
@@ -13,7 +13,7 @@ export function PostNavigation({ previousPost, nextPost }: PostNavigationProps) 
   return (
     <nav
       aria-label="Post navigation"
-      className="not-prose mt-8 flex justify-between gap-4 border-t pt-6"
+      className="not-prose mt-8 flex justify-between gap-4 border-t pt-6 print:hidden"
     >
       {previousPost ? (
         <Link

--- a/components/scroll-progress.tsx
+++ b/components/scroll-progress.tsx
@@ -20,7 +20,7 @@ export default function ScrollProgress() {
 
   return (
     <div
-      className="fixed top-0 left-0 h-1 bg-gradient-to-r from-zinc-300 to-zinc-600"
+      className="fixed top-0 left-0 h-1 bg-gradient-to-r from-zinc-300 to-zinc-600 print:hidden"
       style={{ width: `${scrollProgress}%` }}
     />
   );

--- a/e2e/print.spec.ts
+++ b/e2e/print.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@playwright/test";
+
+// Middle-of-suite post so PostNavigation renders at least one link.
+const POST_URL = "welcome";
+
+test.describe("Print layout", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(POST_URL);
+    await page.emulateMedia({ media: "print" });
+  });
+
+  test("hides header, footer, scroll progress, and post navigation", async ({
+    page,
+  }) => {
+    await expect(page.locator("header")).not.toBeVisible();
+    await expect(page.locator("footer")).not.toBeVisible();
+    await expect(page.locator("div.fixed.top-0.left-0.h-1")).not.toBeVisible();
+    await expect(
+      page.getByRole("navigation", { name: "Post navigation" })
+    ).not.toBeVisible();
+  });
+
+  test("keeps the article title, metadata, and body visible", async ({
+    page,
+  }) => {
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Welcome to the Blog!" })
+    ).toBeVisible();
+    await expect(page.getByText("Igor Souza", { exact: true })).toBeVisible();
+    await expect(page.getByText(/childhood dream coming true/i)).toBeVisible();
+  });
+
+  test("prints black-on-white regardless of the active theme", async ({
+    page,
+  }) => {
+    const bodyBackground = await page.evaluate(
+      () => getComputedStyle(document.body).backgroundColor
+    );
+    expect(bodyBackground).toBe("rgb(255, 255, 255)");
+
+    const headingColor = await page
+      .locator("article h1")
+      .evaluate((el) => getComputedStyle(el).color);
+    expect(headingColor).toBe("rgb(0, 0, 0)");
+  });
+
+  test("code blocks print without a dark background", async ({ page }) => {
+    await page.goto("containerization-a-chroot-with-steroids");
+    await page.emulateMedia({ media: "print" });
+
+    const preBackground = await page
+      .locator("pre")
+      .first()
+      .evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(preBackground).toBe("rgba(0, 0, 0, 0)");
+  });
+});


### PR DESCRIPTION
## Summary

Printing a blog post currently shows the footer's portfolio/social links and mixes dark/light theme colors (dark backgrounds with light text, or vice versa, depending on the active theme). This adds a print stylesheet that:

- Hides the header, footer, scroll-progress bar, and post prev/next navigation on print (via Tailwind's `print:hidden` utility).
- Forces an ink-safe **light** theme in `@media print` — overriding the `.dark` CSS variables and using `!important` to beat inline shiki syntax-highlight colors and the `bg-black` code-block background — so the printed output is always black-on-white regardless of whether the site was in light or dark mode on screen.
- Adds sensible `@page` margins and pagination hygiene (avoid breaking headings/code blocks/images across pages, wrap long code lines instead of clipping them).

## Test plan

- [x] `npm run lint` — no errors.
- [x] New `e2e/print.spec.ts` — verifies header/footer/scroll-progress/post-navigation are hidden in print media, article content stays visible, and body/heading colors are black-on-white; passes across all 4 Playwright projects (light/dark × desktop/mobile).
- [x] Full `npm run test:e2e` suite — 150 passed, 2 skipped (pre-existing), no regressions.
- [x] Visual check: screenshotted a post page with `page.emulateMedia({ media: 'print' })` under both `colorScheme: 'light'` and `colorScheme: 'dark'` — identical white-background/black-text output, no header/footer/nav chrome in either case.

Closes #42

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRjjbsKsrUTroUd83J9xjR)_