### PR TITLE
Fix TTS word-highlight alignment gap, restyle highlight color

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,41 @@ npm run start
 
 The production server will be started on `http://localhost:3000`.
 
+## Check word-highlighting on articles heavy in inline code
+
+The read-aloud player highlights the word currently being spoken by aligning
+the article's DOM text against the TTS engine's word-timing JSON
+(`lib/audio-sync.ts`). This alignment is resilient to most TTS quirks, but
+articles with a lot of unspaced inline code — file paths like
+`` `posts/router.py` ``, chained arrows like `` `a.py → b.py` `` — are still
+the likeliest place for a new edge case to slip through, since `edge-tts`'s
+own word-boundary segmentation for that kind of text is inconsistent (the
+same phrase can come back as one spoken "word" or several, run to run). If
+alignment falls too far out of sync, highlighting silently disables itself
+for that whole article (playback still works fine — only the highlight is
+lost).
+
+Before pushing an article that's dense with inline code/paths, it's worth
+checking word-highlighting actually works rather than assuming it does:
+
+1. Run the TTS pipeline locally against your branch (see
+   `scripts/extract-audio-text.ts` / `scripts/generate_audio.py
+   --local-out <dir>`) to get real timing JSON for the new/edited post —
+   don't rely on hand-written fixture data, since the whole failure mode
+   here only shows up with real `edge-tts` output.
+2. Serve the production build (`npm run build && npm run start`), point
+   `NEXT_PUBLIC_AUDIO_BASE_URL`/a local static server at the `--local-out`
+   directory, open the article, and play it.
+3. Watch whether the highlight moves continuously through the sentences
+   containing inline code — if it goes dark and stays dark, or the whole
+   article never highlights a single word, that's the 20%-unmatched safety
+   threshold in `alignWords` kicking in.
+
+If you hit this, it's a bug in `alignWords`'s matching strategies, not
+something to work around in the article's prose — flag it (or fix it the
+same way past cases were: teaching the matcher a new merge/split pattern),
+rather than rewording the article to dodge the TTS engine's quirk.
+
 ## How to publish the blog changes to github?
 
 There is an [action](./.github/workflows/nextjs.yml) that prepares the project and publish it to Github Pages, so no neet to do anything else, just make sure a production build is creatable.

--- a/lib/audio-sync.ts
+++ b/lib/audio-sync.ts
@@ -18,6 +18,7 @@ export interface TimingWord {
 const WRAPPED_FLAG = "ttsWrapped";
 const LOOKAHEAD = 3;
 const MAX_UNMATCHED_RATIO = 0.2;
+const MAX_MERGE = 6;
 
 /**
  * Wraps every narratable word under `root` in a `<span data-tts-word>` so
@@ -72,6 +73,15 @@ export function wrapWords(root: HTMLElement): {
  * tokenization quirks (splits/merges/dropped punctuation). Returns null if
  * too many TTS words go unmatched, signaling the caller to disable
  * highlighting rather than show unreliable sync.
+ *
+ * edge-tts's own word-boundary segmentation is inconsistent for unspaced
+ * punctuation-joined text (e.g. inline-code paths): "service.py" sometimes
+ * comes back as one boundary event, sometimes split into "service" + "." +
+ * "py". A single DOM token can't be pre-split to match both cases, so when
+ * a direct match fails, this also tries concatenating a short run of
+ * upcoming TTS words' raw text (spaces excluded — TTS words never include
+ * them) to see if it spells out the current unsplit DOM token; if so, all
+ * of those TTS words map to that one DOM span.
  */
 export function alignWords(
   domTokens: string[],
@@ -84,10 +94,12 @@ export function alignWords(
   let domIdx = 0;
   let unmatched = 0;
 
-  for (let ttsIdx = 0; ttsIdx < ttsNormalized.length; ttsIdx++) {
+  let ttsIdx = 0;
+  while (ttsIdx < ttsNormalized.length) {
     const target = ttsNormalized[ttsIdx];
     if (target === "") {
       map[ttsIdx] = domIdx > 0 ? domIdx - 1 : 0;
+      ttsIdx++;
       continue;
     }
 
@@ -103,14 +115,75 @@ export function alignWords(
       }
     }
 
-    if (found === -1) {
-      unmatched++;
-      map[ttsIdx] = domIdx > 0 ? domIdx - 1 : 0;
+    if (found !== -1) {
+      domIdx = found + 1;
+      map[ttsIdx] = found;
+      ttsIdx++;
       continue;
     }
 
-    domIdx = found + 1;
-    map[ttsIdx] = found;
+    let mergedEnd = -1;
+    let merged = "";
+    for (let k = 0; k < MAX_MERGE && ttsIdx + k < tts.length; k++) {
+      merged += tts[ttsIdx + k].t;
+      const normalizedMerged = normalizeForMatch(merged);
+      if (normalizedMerged === "") continue;
+      if (
+        domIdx < domNormalized.length &&
+        domNormalized[domIdx] === normalizedMerged
+      ) {
+        mergedEnd = ttsIdx + k;
+        break;
+      }
+    }
+
+    if (mergedEnd !== -1) {
+      for (let j = ttsIdx; j <= mergedEnd; j++) {
+        map[j] = domIdx;
+      }
+      domIdx += 1;
+      ttsIdx = mergedEnd + 1;
+      continue;
+    }
+
+    // The reverse can also happen: edge-tts occasionally folds several
+    // spoken words into one WordBoundary event (e.g. a numeral getting
+    // merged with the words after it into one "word" of text containing
+    // spaces). Try matching that single TTS target against a run of
+    // consecutive DOM tokens joined by spaces.
+    let domMergedEnd = -1;
+    let domMergedFirst = -1;
+    let domMerged = "";
+    for (let m = 0; m < MAX_MERGE && domIdx + m < domNormalized.length; m++) {
+      const piece = domNormalized[domIdx + m];
+      if (piece === "") continue;
+      domMerged += domMerged === "" ? piece : ` ${piece}`;
+      if (domMergedFirst === -1) domMergedFirst = domIdx + m;
+      if (domMerged === target) {
+        domMergedEnd = domIdx + m;
+        break;
+      }
+    }
+
+    if (domMergedEnd !== -1) {
+      map[ttsIdx] = domMergedFirst;
+      domIdx = domMergedEnd + 1;
+      ttsIdx++;
+      continue;
+    }
+
+    // A DOM token that normalizes to nothing (pure decorative punctuation,
+    // e.g. the "→" between inline-code paths) has no TTS word of its own —
+    // skip it without consuming a TTS word, instead of permanently
+    // stalling domIdx on a token nothing will ever match again.
+    if (domIdx < domNormalized.length && domNormalized[domIdx] === "") {
+      domIdx++;
+      continue;
+    }
+
+    unmatched++;
+    map[ttsIdx] = domIdx > 0 ? domIdx - 1 : 0;
+    ttsIdx++;
   }
 
   if (tts.length > 0 && unmatched / tts.length > MAX_UNMATCHED_RATIO) {

--- a/styles/mdx.css
+++ b/styles/mdx.css
@@ -39,5 +39,5 @@
 }
 
 .tts-active-word {
-  @apply rounded-sm bg-amber-200/80 dark:bg-amber-500/30;
+  @apply rounded-sm bg-green-700/25 dark:bg-green-500/30;
 }


### PR DESCRIPTION
## Summary

Found while verifying #45/#47 live on production: 3 of the 6 published posts (`domain-driven-design-...`, `kafka-consumers-fastapi-...`, plus edge cases in others) shipped with word-highlighting silently disabled, even though audio played fine. Root cause was in `lib/audio-sync.ts`'s `alignWords` (shipped in #46, unrelated to the TTS pipeline itself) — `edge-tts`'s own word-boundary segmentation is inconsistent for unspaced punctuation-joined text:

- `auth/router.py` sometimes comes back as **one** `WordBoundary` event, sometimes split into `auth` / `/` / `router` / `.` / `py`.
- A numeral occasionally folds into a multi-word blob, e.g. one event with text `"4 partitions and you run"`.
- Once the greedy DOM↔TTS matcher desynced on an unmatchable token (like the `→` separator between two inline-code paths, which has no TTS word of its own), it never recovered — pushing the unmatched ratio for the rest of the article well past the 20% safety threshold, disabling highlighting entirely.

`alignWords` now tries, in order: a direct match, concatenating a short run of upcoming TTS words to see if they spell out the current unsplit DOM token, the reverse (one TTS word matching a run of consecutive DOM tokens), and finally skipping DOM tokens that normalize to nothing (pure decorative punctuation) so they can't permanently stall the pointer.

Also swapped the active-word highlight color from amber to dark green per feedback (`styles/mdx.css`).

Added a README section pointing future article authors at how to manually check highlighting on inline-code-heavy posts before pushing — this class of bug only reproduces against real `edge-tts` output, not fixture data, so no CI check was added (see discussion in the PR/issue history — this is a dev-time check, not a pipeline gate).

## Verification

- Fetched real TTS timing JSON + live rendered HTML for all 6 currently-published posts from the production S3 bucket/site and ran the real `wrapWords`/`alignWords` against them directly (not fixture data): **all 6 now align 100% of their words** (previously 3 of 6 returned `null`, disabling highlighting).
- `npm run lint` — clean.
- `npm run test:e2e` — full suite, 182 passed / 2 skipped / 0 failed, including the existing fixture-based highlighting test.

## Test plan

- [x] Verified against real production TTS data for all 6 posts (see above).
- [x] Full e2e suite green, no regressions.
- [ ] After merge, spot-check the live `domain-driven-design-...` and `kafka-consumers-...` articles in a browser to confirm highlighting now works end-to-end (not just in the isolated alignment check).