### PR TITLE
Fix audio player stuck on "Couldn't connect" after closing mid-probe

### DIFF
--- a/components/audio-player.tsx
+++ b/components/audio-player.tsx
@@ -69,7 +69,15 @@ export function AudioPlayer({ slug }: AudioPlayerProps) {
   }, []);
 
   useEffect(() => {
-    if (!open || hasProbedRef.current) return;
+    // Closing the player (or the underlying component surviving a
+    // soft/back navigation) must allow a fresh probe next time it opens —
+    // otherwise a probe aborted by our own cleanup below gets permanently
+    // stuck in "error" with no way to retry.
+    if (!open) {
+      hasProbedRef.current = false;
+      return;
+    }
+    if (hasProbedRef.current) return;
     hasProbedRef.current = true;
 
     if (!base || !mp3Url) {
@@ -78,6 +86,7 @@ export function AudioPlayer({ slug }: AudioPlayerProps) {
     }
 
     setState("checking");
+    let cancelledByCleanup = false;
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
 
@@ -86,6 +95,10 @@ export function AudioPlayer({ slug }: AudioPlayerProps) {
         setState(res.ok ? "ready" : "unavailable");
       })
       .catch(() => {
+        // Ignore aborts caused by our own cleanup (dialog closed, deps
+        // changed) — only a genuinely failed/timed-out request while the
+        // player is still open is a real "couldn't connect" error.
+        if (cancelledByCleanup) return;
         setState("error");
       })
       .finally(() => {
@@ -93,6 +106,7 @@ export function AudioPlayer({ slug }: AudioPlayerProps) {
       });
 
     return () => {
+      cancelledByCleanup = true;
       clearTimeout(timeout);
       controller.abort();
     };

--- a/e2e/audio-player.spec.ts
+++ b/e2e/audio-player.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect } from "@playwright/test";
-import { routeAudio } from "./fixtures/tts";
+import {
+  AUDIO_FIXTURE_BASE,
+  fixtureDurationSeconds,
+  makeSilentWav,
+  makeTimingJson,
+  routeAudio,
+} from "./fixtures/tts";
 
 // Real S3 latency/CORS behavior, real edge-tts audio, and the generation
 // pipeline itself aren't e2e-testable here — they're covered by the
@@ -104,6 +110,61 @@ test.describe("Audio player", () => {
     await expect(dialog.getByRole("button", { name: "Pause" })).toBeVisible();
     await page.waitForTimeout(1000);
     await expect(page.locator("span.tts-active-word")).toHaveCount(0);
+  });
+
+  test("closing the player mid-probe doesn't stick it in an error state on reopen", async ({
+    page,
+  }) => {
+    // Regression for: aborting the in-flight HEAD probe on close (via the
+    // effect's own cleanup) was being reported as a genuine connection
+    // error, and a ref guard meant the player never probed again — so
+    // closing quickly, then reopening, got stuck showing "Couldn't
+    // connect to the audio service" forever, even though the audio was
+    // actually available.
+    let resolveProbe: () => void = () => {};
+    const probeGate = new Promise<void>((resolve) => {
+      resolveProbe = resolve;
+    });
+
+    await page.route(`${AUDIO_FIXTURE_BASE}/${SLUG}.mp3`, async (route) => {
+      await probeGate;
+      await route.fulfill({
+        status: 200,
+        contentType: "audio/wav",
+        body: makeSilentWav(fixtureDurationSeconds()),
+      });
+    });
+    await page.route(`${AUDIO_FIXTURE_BASE}/${SLUG}.json`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(makeTimingJson(SLUG)),
+      });
+    });
+
+    await page.goto(POST_URL);
+    const openButton = page.getByRole("button", {
+      name: /listen to this article/i,
+    });
+    const dialog = page.getByRole("dialog", { name: /audio player/i });
+
+    // Open while the probe is still pending, then close before it resolves.
+    await openButton.click();
+    await expect(dialog.getByText(/checking for audio/i)).toBeVisible();
+    await dialog.getByRole("button", { name: /close player/i }).click();
+    await expect(dialog).toBeHidden();
+
+    // Let the (now-aborted, from the player's perspective) first probe's
+    // response land — it must not leak into the next probe's state.
+    resolveProbe();
+
+    await openButton.click();
+    await expect(
+      dialog.getByText(/couldn't connect to the audio service/i)
+    ).toHaveCount(0);
+    await expect(
+      dialog.getByRole("button", { name: "Play", exact: true })
+    ).toBeVisible({ timeout: 10_000 });
   });
 
   test("article auto-scrolls to follow the highlighted word", async ({


### PR DESCRIPTION
## Summary

Reported: play an article's audio, leave the page, come back — get "Couldn't connect to the audio service. Try again later." even though the audio is actually fine. Reproduced consistently, including in incognito.

Root cause was two compounding bugs in `components/audio-player.tsx`'s availability-probe effect:

1. `hasProbedRef` was set to `true` **before** the HEAD probe even resolved, and never reset — so a given player instance only ever attempts the probe once, ever, regardless of outcome. No retry path existed.
2. Closing the dialog (or the component surviving a soft/back navigation without a full remount) runs the effect's own cleanup, which calls `controller.abort()` on the in-flight `fetch`. That abort was indistinguishable from a genuine connection failure in the `.catch()` handler, so closing the player before the probe finished landed it in the `"error"` state — permanently, because of bug 1.

## Fix

- `open` transitioning to `false` now resets `hasProbedRef.current`, so reopening the player always re-probes fresh.
- A `cancelledByCleanup` flag set synchronously in the effect's cleanup lets the `.catch()` handler tell "we aborted this ourselves" apart from a real failed/timed-out request — only the latter shows the "Couldn't connect" message.

## Test plan

- [x] Added an e2e regression test (`e2e/audio-player.spec.ts`): opens the player while the probe is deliberately held pending, closes it before the probe resolves, then reopens and asserts it recovers to a working player instead of sticking on the error message.
- [x] Confirmed the new test **fails** against the pre-fix code with exactly the reported error message, and **passes** with the fix (verified via `git stash` before finalizing).
- [x] `npm run lint` — clean.
- [x] `npm run test:e2e` — full suite, 186 passed / 2 skipped / 0 failed.