### PR TITLE
Fix header logo prefetch 404, root cause of console CORS error and audio-probe aborts

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -7,7 +7,7 @@ export default function Header(){
   return (
     <header className="py-6 lg:py-10 print:hidden">
       <div className="flex gap-4 flex-row justify-between md:gap-8">
-        <Link className="hidden sm:inline-block" href="/">
+        <Link className="hidden sm:inline-block" href="/" prefetch={false}>
           <Logo size={36}/>
         </Link>
         <nav className="my-auto text-xl">


### PR DESCRIPTION
## Summary

Closes #48. Root-caused the console errors reported after #45/#49/#50 — the "CORS" error on the audio HEAD probe, the chunk-load errors on plain navigation, all of it traced to one thing.

**Root cause**: `components/header.tsx`'s logo — `<Link href="/">` — sits above the fold on every page, so Next.js auto-prefetches its RSC ("flight") payload on load. Under this repo's static export + non-empty `basePath` (`/blog`) combination, the client computes that payload's URL as `/blog.txt` — but the file the static export actually generates is `out/index.txt`, served (via GitHub Pages' repo-name-as-path-prefix behavior) at `/blog/index.txt`. The prefetch request 404s every single page load. On the live site, that 404 cascades into `Failed to fetch RSC payload... Falling back to browser navigation` — Next.js triggering a full page reload — which aborts every in-flight request on the page, including the audio player's availability probe. **That abort is what Chrome was misreporting as a CORS block** in the console; the S3 bucket's CORS config was correct the entire time (verified directly against production — `access-control-allow-origin` present on every response).

Fix: `prefetch={false}` on that one Link. Checked every other same-origin `next/link` usage in the app (`post-navigation.tsx`, `post-item.tsx`, `tag.tsx`, `mdx-card.tsx`, `footer.tsx`) — none of them point at `/`, the one route where `basePath + ".txt"` collides with the RSC payload path this way, so this is the complete fix.

## Verification

Built a real static export locally (temporary `output: "export"` in `next.config.mjs`, not committed — that's normally injected at build time by `actions/configure-pages@v5` in `nextjs.yml`) and served `out/` under `/blog/` with a plain Python static file server, to match GitHub Pages' actual behavior (the dev/prod `next start` server doesn't reproduce this — it has a live RSC endpoint, unlike static hosting).

- **Without the fix**: loading the homepage throws exactly the reported error — `GET /blog.txt?_rsc=... 404`.
- **With the fix**: zero console errors on load.

Also confirmed against the live production site directly (via a real headless Chromium session hitting `igormcsouza.github.io/blog/`) before diagnosing this — reproduced the exact chunk-load cascade from a plain link click with zero audio interaction, ruling out the audio player code as the source.

- [x] `npm run lint` — clean.
- [x] `npm run test:e2e` — full suite, 186 passed / 2 skipped / 0 failed.
- [ ] After merge, confirm the live site shows zero console errors on load and the audio player survives close/reopen without the "Couldn't connect" message.

Closes #48