### PR TITLE
Disable prefetch on remaining internal links (#48 wasn't fully fixed by #51)

### DIFF
--- a/components/mdx-card.tsx
+++ b/components/mdx-card.tsx
@@ -29,7 +29,7 @@ export function MdxCard({
         </div>
       </div>
       {href && (
-        <Link href={disabled ? "#" : href} className="absolute inset-0">
+        <Link href={disabled ? "#" : href} prefetch={false} className="absolute inset-0">
           <span className="sr-only">View</span>
         </Link>
       )}

--- a/components/post-item.tsx
+++ b/components/post-item.tsx
@@ -23,7 +23,7 @@ export function PostItem({
     <article className="flex flex-col gap-2 border-border border-b py-3">
       <div>
         <h2 className="text-2xl font-bold">
-          <Link href={"/" + slug}>{title}</Link>
+          <Link href={"/" + slug} prefetch={false}>{title}</Link>
         </h2>
       </div>
       <div className="flex flex-wrap gap-2">
@@ -42,6 +42,7 @@ export function PostItem({
         </dl>
         <Link
           href={"/" + slug}
+          prefetch={false}
           className={cn(buttonVariants({ variant: "link" }), "py-0")}
         >
           Read more →

--- a/components/post-navigation.tsx
+++ b/components/post-navigation.tsx
@@ -18,6 +18,7 @@ export function PostNavigation({ previousPost, nextPost }: PostNavigationProps) 
       {previousPost ? (
         <Link
           href={"/" + previousPost.slug}
+          prefetch={false}
           className="group flex max-w-[45%] flex-col gap-1 py-2"
         >
           <span className="flex items-center gap-1 text-sm text-muted-foreground">
@@ -33,6 +34,7 @@ export function PostNavigation({ previousPost, nextPost }: PostNavigationProps) 
       {nextPost ? (
         <Link
           href={"/" + nextPost.slug}
+          prefetch={false}
           className="group ml-auto flex max-w-[45%] flex-col items-end gap-1 py-2 text-right"
         >
           <span className="flex items-center gap-1 text-sm text-muted-foreground">

--- a/components/tag.tsx
+++ b/components/tag.tsx
@@ -15,6 +15,7 @@ export function Tag({ tag, current, count }: TagProps) {
         className: "no-underline rounded-md",
       })}
       href={`/tags/${slug(tag)}`}
+      prefetch={false}
     >
       {tag} {count ? `(${count})` : null}
     </Link>


### PR DESCRIPTION
## Summary

#51 fixed the header logo's prefetch 404, but verifying live after that merge/deploy showed the same class of error persisting on the homepage — different chunk hashes, same root cause. The homepage renders every post's title + "Read more" link (`post-item.tsx`, 2 links × 6 posts) and every tag chip (`tag.tsx`) — a dozen-plus same-origin `next/link`s all near-viewport at once, each auto-prefetched by Next.js. `post-navigation.tsx`'s prev/next links and `mdx-card.tsx`'s internal links have the same exposure, just less consistently triggered depending on page content.

Given this Next.js version (14.1.4) can't be trusted with automatic prefetch under this static-export + `basePath` combination — and prefetch buys a fully static site very little anyway — this disables it on every remaining same-origin `next/link` in the app: `post-item.tsx` (both links), `post-navigation.tsx` (both links), `tag.tsx`, `mdx-card.tsx`.

`footer.tsx`'s links are all absolute cross-origin URLs (`igormcsouza.github.io`, GitHub, X, LinkedIn, Instagram) — Next never prefetches those regardless of the `prefetch` prop, so no change needed there. This is now the complete set of same-origin `next/link` usages in the app.

## Verification

Rebuilt a real static export locally (temporary `output: "export"`, not committed) and served it under `/blog/` with a plain static file server, matching GitHub Pages' actual behavior:

- **With only #51's header fix** (no other changes): loading the homepage still threw chunk-load errors referencing hashes absent from the current build's manifest — confirming #48 wasn't fully closed by #51 alone.
- **With this PR's changes on top**: zero console errors loading the homepage.

- [x] `npm run lint` — clean.
- [x] `npm run test:e2e` — full suite, 186 passed / 2 skipped / 0 failed.
- [ ] After merge, confirm the live homepage and the audio player (close/reopen) show zero console errors.