### PR TITLE
Fix RSC payload URL 404 by enabling trailingSlash (real root cause of #48)

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -11,7 +11,7 @@ test.describe("Header navigation", () => {
   test("Tags link goes to the tags index", async ({ page }) => {
     await page.goto("");
     await page.getByRole("navigation").getByRole("link", { name: "Tags" }).click();
-    await expect(page).toHaveURL(/\/blog\/tags$/);
+    await expect(page).toHaveURL(/\/blog\/tags\/?$/);
     await expect(page.getByRole("heading", { level: 1, name: "Tags" })).toBeVisible();
   });
 

--- a/e2e/post-navigation.spec.ts
+++ b/e2e/post-navigation.spec.ts
@@ -49,7 +49,7 @@ test.describe("Post navigation", () => {
     const nav = page.getByRole("navigation", { name: "Post navigation" });
 
     await nav.getByRole("link", { name: /Welcome to the Blog!/ }).click();
-    await expect(page).toHaveURL(new RegExp(`/blog/${OLDEST_POST}$`));
+    await expect(page).toHaveURL(new RegExp(`/blog/${OLDEST_POST}/?$`));
   });
 
   test("clicking the next link navigates to the newer post", async ({
@@ -59,6 +59,6 @@ test.describe("Post navigation", () => {
     const nav = page.getByRole("navigation", { name: "Post navigation" });
 
     await nav.getByRole("link", { name: /We need to talk about GIL!/ }).click();
-    await expect(page).toHaveURL(new RegExp(`/blog/${MIDDLE_POST}$`));
+    await expect(page).toHaveURL(new RegExp(`/blog/${MIDDLE_POST}/?$`));
   });
 });

--- a/e2e/post.spec.ts
+++ b/e2e/post.spec.ts
@@ -75,6 +75,6 @@ test.describe("Post page", () => {
   }) => {
     await page.goto(POST_URL);
     await page.getByRole("link", { name: "welcome" }).click();
-    await expect(page).toHaveURL(/\/blog\/tags\/welcome$/);
+    await expect(page).toHaveURL(/\/blog\/tags\/welcome\/?$/);
   });
 });

--- a/e2e/tags.spec.ts
+++ b/e2e/tags.spec.ts
@@ -13,7 +13,7 @@ test.describe("Tags index page", () => {
     const tagLink = page.getByRole("link", { name: /welcome \(\d+\)/i });
     await expect(tagLink).toBeVisible();
     await tagLink.click();
-    await expect(page).toHaveURL(/\/blog\/tags\/welcome$/);
+    await expect(page).toHaveURL(/\/blog\/tags\/welcome\/?$/);
   });
 });
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   basePath: "/blog",
+  trailingSlash: true,
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Found the actual root cause of the console errors and audio-player disruptions that survived #50, #51, and #52 — directly in **Next.js 14.1.4's own shipped router code** (`_next/static/chunks/69-*.js`), not in anything in this app:

```js
t.pathname.endsWith("/") ? t.pathname += "index.txt" : t.pathname += ".txt"
```

This computes the URL Next fetches to keep its client-side router cache warm for the root route "/" (a framework-internal mechanism, independent of any specific `<Link>`'s `prefetch` prop — which is exactly why #51's and #52's `prefetch={false}` changes, while independently reasonable cleanup, never actually fixed this). Under this repo's `basePath: "/blog"` with no `trailingSlash`, the router computes the root pathname as `"/blog"` — doesn't end in `/` — so it appends `.txt`, producing `/blog.txt`. The static export actually generates `index.txt` at that route (served at `/blog/index.txt` via GitHub Pages' repo-name-as-path-prefix behavior), so `/blog.txt` 404s on **every single page load**.

That 404 cascades into `Failed to fetch RSC payload... Falling back to browser navigation` — a full page reload — which aborts any other in-flight request on the page, including the audio player's S3 probe. That abort is what repeatedly surfaced as a misleading "blocked by CORS" console error, and as a genuine `net::ERR_FAILED`/"Couldn't connect" failure in real browsers (desktop Chrome, incognito, and mobile Samsung Internet — all reproduced it identically). It's also why extensive `curl` testing (60+ concurrent requests matching real headers, HTTP/2, IPv6) could never reproduce it: curl never has a concurrent page-reload-triggered abort in flight the way a real browser session does.

**Fix**: `trailingSlash: true` makes Next consistently generate `/blog/` (not `/blog`) as the root path under this basePath, so the same router logic correctly computes `/blog/index.txt` — matching the real file.

## Verification

Rebuilt a real static export and served it under `/blog/` exactly like GitHub Pages:
- **Without this fix**: homepage load, click-through navigation, and reload all show the `/blog.txt` 404 → chunk-load-error cascade.
- **With the fix**: zero console errors across homepage load, click-through, and reload.

e2e URL assertions updated to tolerate the now-present trailing slash (`navigation.spec.ts`, `post-navigation.spec.ts`, `post.spec.ts`, `tags.spec.ts`) — this is correct/intentional new behavior, not a regression.

- [x] `npm run lint` — clean.
- [x] `npm run test:e2e` — full suite, 186 passed / 2 skipped / 0 failed.
- [ ] After merge, confirm on the live site: reproduce the original "play audio → reload → play again" sequence across desktop and mobile and confirm it now works cleanly.

Closes #48