### PR TITLE
Add Docker Compose GitHub Pages replica for local testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+.next
+out
+.velite
+.audio-build
+scripts/.venv
+test-results
+playwright-report
+.git

--- a/README.md
+++ b/README.md
@@ -82,6 +82,39 @@ something to work around in the article's prose — flag it (or fix it the
 same way past cases were: teaching the matcher a new merge/split pattern),
 rather than rewording the article to dodge the TTS engine's quirk.
 
+## Testing against a GitHub Pages-like local server
+
+`npm run build && npm run start` runs Next's own dev server, which behaves
+differently from the real deployment in one important way: GitHub Pages
+serves a **static export** (`out/`) with no live Next.js server behind it —
+no dynamic RSC endpoint, no image optimization endpoint. Bugs specific to
+that (broken client-side prefetch URLs, missing files, basePath edge cases)
+won't reproduce under `next start` at all.
+
+`docker-compose.yml` builds the actual static export (`STATIC_EXPORT=true
+next build`, same as `actions/configure-pages` does in CI) and serves it
+through nginx configured to mimic GitHub Pages' behavior as closely as
+possible: served at the `/blog/` basePath, extensionless URL resolution
+(`/blog/some-post` → `some-post.html` or `some-post/index.html`), and a
+custom 404 page.
+
+```bash
+docker compose up --build
+```
+
+Serves at `http://localhost:45678/blog/` (override the port with
+`BLOG_DOCKER_PORT`). `NEXT_PUBLIC_AUDIO_BASE_URL` defaults to the real
+production audio bucket so the read-aloud player works against real data;
+override it via the same-named env var to point at a local `--local-out`
+directory instead.
+
+**Caveat**: this replicates GitHub Pages' file/routing layout, not its CDN
+(Fastly) behavior — some bugs (particularly ones this repo has hit around
+client-side RSC prefetch cascades) have only reproduced on the *actual*
+deployed site, not in this local replica or in `next start`. Use it to
+catch routing/basePath/static-export bugs early, but confirm anything
+network/CDN-shaped against the real deployment before calling it fixed.
+
 ## How to publish the blog changes to github?
 
 There is an [action](./.github/workflows/nextjs.yml) that prepares the project and publish it to Github Pages, so no neet to do anything else, just make sure a production build is creatable.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  blog:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      args:
+        NEXT_PUBLIC_AUDIO_BASE_URL: ${NEXT_PUBLIC_AUDIO_BASE_URL:-https://igormcsouza-blog-audio.s3.us-east-1.amazonaws.com/audio}
+    ports:
+      - "${BLOG_DOCKER_PORT:-45678}:80"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:20-slim AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+ENV STATIC_EXPORT=true
+ARG NEXT_PUBLIC_AUDIO_BASE_URL=https://igormcsouza-blog-audio.s3.us-east-1.amazonaws.com/audio
+ENV NEXT_PUBLIC_AUDIO_BASE_URL=${NEXT_PUBLIC_AUDIO_BASE_URL}
+
+RUN npx velite build && npx next build
+
+FROM nginx:1.27-alpine
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/out /usr/share/nginx/html/blog

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+
+    # GitHub Pages serves this repo at igormcsouza.github.io/blog/ (the
+    # basePath) — replicate that path shape locally instead of serving the
+    # static export at the server root.
+    location = / {
+        return 302 /blog/;
+    }
+
+    location /blog/ {
+        # Mirrors GitHub Pages' extensionless static-file resolution:
+        # exact match, then "<path>.html", then "<path>/index.html".
+        try_files $uri $uri.html $uri/index.html $uri/ =404;
+    }
+
+    error_page 404 /blog/404.html;
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,14 @@
 const nextConfig = {
   basePath: "/blog",
   trailingSlash: true,
+  // GitHub Pages deploys a static export — actions/configure-pages injects
+  // `output: "export"` (plus unoptimized images) at build time in CI, so a
+  // plain local `next build` doesn't normally produce one. STATIC_EXPORT
+  // lets the Docker Compose replica (docker/) opt into the same static
+  // export CI produces, without changing local dev/build/e2e behavior.
+  ...(process.env.STATIC_EXPORT === "true"
+    ? { output: "export", images: { unoptimized: true } }
+    : {}),
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

\`npm run dev\`/\`npm run start\` run a live Next.js server, which can't reproduce bugs specific to GitHub Pages' actual deployment shape: a static export with no server behind it at all. Several real bugs hit during the #48 investigation (RSC-prefetch cascades, basePath/extensionless-URL mismatches — see #51/#53/#54) only ever reproduced against a properly-built static export or the live site itself, never under \`next start\`.

\`next.config.mjs\`: \`output: "export"\` + \`images.unoptimized\` now activate under \`STATIC_EXPORT=true\`, matching what \`actions/configure-pages\` injects in CI — inert otherwise, verified a plain \`next build\` still produces no \`out/\` dir and normal dev/build/e2e are unaffected.

\`docker/Dockerfile\` builds that static export and serves it via nginx configured to mimic GitHub Pages: served under the \`/blog/\` basePath, extensionless URL resolution (exact match → \`.html\` → directory \`index.html\`), custom 404 page.

\`docker-compose.yml\` wires it up on port 45678 (\`BLOG_DOCKER_PORT\` to override), with \`NEXT_PUBLIC_AUDIO_BASE_URL\` defaulting to the real production audio bucket so the read-aloud player works out of the box.

Documented in the README with an explicit caveat: this replicates GitHub Pages' file/routing layout, not its CDN (Fastly) behavior or browser-side HTTP caching — useful for catching routing/basePath/static-export bugs early (which is exactly how it was validated), but not a substitute for verifying network/CDN/cache-shaped issues against the real deployment.

## Verification

- [x] \`docker compose up --build\` — builds and serves cleanly at \`http://localhost:45678/blog/\`.
- [x] Verified URL resolution: root redirect, extensionless post routes, \`404\` page, and the specific \`index.txt\` RSC-payload path from #53/#54 all resolve correctly.
- [x] \`npm run lint\` — clean.
- [x] Confirmed \`STATIC_EXPORT\` env gating doesn't affect a normal \`next build\` (no \`out/\` dir produced without it).