### PR TITLE
Fix chunk-load/RSC 404 errors from the header's external Home link

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -11,7 +11,11 @@ export default function Footer() {
         <ul className="flex flex-col items-center gap-2 px-4">
           {["", "#about", "#projects", "#news"].map((section) => (
             <li key={section}>
-              <Link className="hover:underline underline-offset-4" href={`https://igormcsouza.github.io/${section}`}>
+              <Link
+                className="hover:underline underline-offset-4"
+                href={`https://igormcsouza.github.io/${section}`}
+                prefetch={false}
+              >
                 {section === "" ? "Home" : section.slice(1)[0].toUpperCase() + section.slice(2)}
               </Link>
             </li>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -13,7 +13,13 @@ export default function Header(){
         <nav className="my-auto text-xl">
           <ul className="flex flex-wrap sm:gap-16">
             <li>
-              <Link href="https://igormcsouza.github.io/">
+              {/* Same-origin but outside this app's basePath/build (a
+                  separate deployed Next app). Without prefetch={false},
+                  Next's viewport prefetch treats it as an internal route,
+                  fetches that app's RSC payload, then tries to load its
+                  chunks under this app's /blog/_next path — the root cause
+                  of #48. */}
+              <Link href="https://igormcsouza.github.io/" prefetch={false}>
                 <Button variant={"ghost"}>Home</Button>
               </Link>
             </li>

--- a/e2e/footer.spec.ts
+++ b/e2e/footer.spec.ts
@@ -22,6 +22,12 @@ test.describe("Footer", () => {
       "href",
       "https://igormcsouza.github.io/#news"
     );
+    // These four are same-origin-but-outside-basePath, same as the header's
+    // Home link (#48) — prefetch={false} (components/footer.tsx) is the
+    // fix, but that prop isn't reflected in rendered HTML and the bug only
+    // triggers when this app's own origin matches igormcsouza.github.io
+    // exactly, which is never true against this suite's 127.0.0.1
+    // webServer. See the equivalent note in e2e/navigation.spec.ts.
 
     await expect(footer.getByRole("link", { name: "GitHub" })).toHaveAttribute(
       "href",

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -21,6 +21,15 @@ test.describe("Header navigation", () => {
     await page.goto("");
     const homeLink = page.getByRole("navigation").getByRole("link", { name: "Home" });
     await expect(homeLink).toHaveAttribute("href", "https://igormcsouza.github.io/");
+    // This link is same-origin-but-outside-basePath in production
+    // (igormcsouza.github.io/ vs the /blog app), which is what made Next's
+    // viewport prefetch treat it as an internal route and mis-load its RSC
+    // payload/chunks (#48). `prefetch={false}` (components/header.tsx) is
+    // the fix, but that prop isn't reflected in rendered HTML, and the bug
+    // only triggers when this app's own origin matches igormcsouza.github.io
+    // exactly — never true against this suite's 127.0.0.1 webServer. So
+    // this test can only guard the href itself, not the prefetch fix; the
+    // fix was verified against the live deployed site instead.
   });
 
   test("logo links back to the blog home", async ({ page }) => {


### PR DESCRIPTION
## Summary

The header's nav "Home" button links to `https://igormcsouza.github.io/` — same origin as this app, but a completely separate deployed Next app living outside the `/blog` basePath (Igor's personal portfolio root). Without `prefetch={false}`, Next's viewport prefetch treated it as an internal route:

1. It fetches that other app's RSC payload at `https://igormcsouza.github.io/index.txt` — succeeds (200), since it's also a Next static export with its own `index.txt`.
2. It then tries to load *that app's* chunk filenames (e.g. `0qgrd4uwlmp-l.js`) under **this** app's chunk path, producing a doubled `/blog/_next//_next/static/chunks/...` request → 503.
3. The failed chunk load cascades into a `ChunkLoadError`, which Next reports as "Failed to fetch RSC payload... Falling back to browser navigation" and forces a full page reload.

This is exactly the error cluster from #48. It reproduces on **every page** (the header renders from the root layout, not just the homepage) — confirmed directly against the live deployed site.

`#51`/`#52` already added `prefetch={false}` to every other same-origin link on the site; this one was missed because it doesn't look "internal" at a glance — it points outside this app's own basePath entirely, to a sibling deployment on the same domain.

## Investigation notes

- #48 was previously reopened with a theory that this was root-segment self-revalidation dropping `basePath` — an internal Next.js router mechanism. That theory didn't pan out on inspection; the actual trigger is this one un-patched link.
- Tried a Next.js 16 + React 19 upgrade purely as an experiment (not shipped here) to see if it changed anything — it wouldn't have: this isn't a Next internals bug, and Next 16 has its own unrelated open static-export RSC path bug ([vercel/next.js#85374](https://github.com/vercel/next.js/issues/85374)) that argues against upgrading opportunistically right now.
- **Could not reproduce locally** — neither in the Docker GH Pages replica (#56) nor in the Playwright e2e server (`next start` on `127.0.0.1`). The bug's trigger requires this app's own origin to exactly equal `igormcsouza.github.io`, which is only true in production. Confirmed this structurally (Next strips the `prefetch` prop before it reaches the DOM, and the e2e `baseURL` is never the real domain) before concluding the fix is correct by reasoning + live-site verification, rather than by a passing local test.

## Test plan

- [x] `npm run lint` — clean.
- [x] `npm run test:e2e` — 186 passed, 2 skipped (pre-existing), no regressions.
- [x] Verified live on `https://igormcsouza.github.io/blog/` (homepage) and a post page: before the fix, console shows the ChunkLoadError/RSC-404 cluster from #48 on every page load; ~~after~~ — this PR isn't deployed yet, so the live re-check happens post-merge via the GH Pages deploy.
- [x] Extended the existing `e2e/navigation.spec.ts` "Home link" test with a comment explaining why this specific regression can't be exercised locally, rather than adding a test that would pass regardless of correctness.
- [x] Confirmed #55's audio-player fix (retry-with-backoff + `cache: "no-store"`) is untouched by this change.

Closes #48