### PR TITLE
Add event-driven architecture post with live Mermaid C4 diagrams

### DIFF
--- a/components/mdx-component.tsx
+++ b/components/mdx-component.tsx
@@ -1,10 +1,18 @@
 import * as React from "react"
 import * as runtime from "react/jsx-runtime";
 import Image from "next/image"
+import dynamic from "next/dynamic"
 
 import { cn } from "@/lib/utils"
 import { Callout } from "@/components/callout"
 import { MdxCard } from "@/components/mdx-card"
+
+// Mermaid renders to SVG client-side only (it touches the DOM directly and
+// isn't meaningful to prerender), so it's excluded from SSR entirely.
+const Mermaid = dynamic(
+  () => import("@/components/mermaid").then((mod) => mod.Mermaid),
+  { ssr: false }
+)
 
 const components = {
   h1: ({ className, ...props }: { className?: string }) => (
@@ -150,6 +158,7 @@ const components = {
   Image,
   Callout,
   Card: MdxCard,
+  Mermaid,
 }
 
 const useMDXComponent = (code: string) => {

--- a/components/mermaid.tsx
+++ b/components/mermaid.tsx
@@ -25,6 +25,13 @@ export function Mermaid({ chart }: MermaidProps) {
         startOnLoad: false,
         theme: theme === "dark" ? "dark" : "default",
         securityLevel: "strict",
+        // Render at natural size and let the wrapper's overflow-x-auto
+        // handle wide diagrams (same pattern as this blog's code blocks),
+        // instead of Mermaid shrinking the SVG to fit the article column
+        // and crowding every label.
+        flowchart: { useMaxWidth: false },
+        sequence: { useMaxWidth: false },
+        c4: { useMaxWidth: false },
       })
 
       try {

--- a/components/mermaid.tsx
+++ b/components/mermaid.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import * as React from "react"
+
+import { useThemeContext } from "@/context"
+
+interface MermaidProps {
+  chart: string
+}
+
+export function Mermaid({ chart }: MermaidProps) {
+  const { theme } = useThemeContext()
+  const uid = React.useId().replace(/:/g, "")
+  const [svg, setSvg] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    // Wait for ThemeContextProvider to resolve the actual theme (it starts
+    // undefined) so the diagram is never rendered in the wrong palette.
+    if (!theme) return
+
+    let cancelled = false
+
+    import("mermaid").then(async ({ default: mermaid }) => {
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: theme === "dark" ? "dark" : "default",
+        securityLevel: "strict",
+      })
+
+      try {
+        const { svg: rendered } = await mermaid.render(`mermaid-${uid}`, chart)
+        if (!cancelled) setSvg(rendered)
+      } catch (error) {
+        console.error("Failed to render Mermaid diagram", error)
+      }
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [chart, theme, uid])
+
+  return (
+    <div
+      data-mermaid=""
+      className="my-6 flex justify-center overflow-x-auto rounded-lg border p-4"
+      {...(svg ? { dangerouslySetInnerHTML: { __html: svg } } : {})}
+    />
+  )
+}

--- a/components/mermaid.tsx
+++ b/components/mermaid.tsx
@@ -8,8 +8,6 @@ interface MermaidProps {
   chart: string
 }
 
-let iconsRegistered = false
-
 export function Mermaid({ chart }: MermaidProps) {
   const { theme } = useThemeContext()
   const uid = React.useId().replace(/:/g, "")
@@ -23,16 +21,6 @@ export function Mermaid({ chart }: MermaidProps) {
     let cancelled = false
 
     import("mermaid").then(async ({ default: mermaid }) => {
-      if (!iconsRegistered) {
-        mermaid.registerIconPacks([
-          {
-            name: "logos",
-            loader: () => import("@iconify-json/logos").then((m) => m.icons),
-          },
-        ])
-        iconsRegistered = true
-      }
-
       mermaid.initialize({
         startOnLoad: false,
         theme: theme === "dark" ? "dark" : "default",
@@ -44,7 +32,6 @@ export function Mermaid({ chart }: MermaidProps) {
         flowchart: { useMaxWidth: false },
         sequence: { useMaxWidth: false },
         c4: { useMaxWidth: false },
-        architecture: { useMaxWidth: false },
         themeVariables: {
           // Explicit, high-contrast colors for subgraph/cluster titles —
           // the built-in dark theme's default clusterBkg is dark enough

--- a/components/mermaid.tsx
+++ b/components/mermaid.tsx
@@ -8,6 +8,8 @@ interface MermaidProps {
   chart: string
 }
 
+let iconsRegistered = false
+
 export function Mermaid({ chart }: MermaidProps) {
   const { theme } = useThemeContext()
   const uid = React.useId().replace(/:/g, "")
@@ -21,6 +23,16 @@ export function Mermaid({ chart }: MermaidProps) {
     let cancelled = false
 
     import("mermaid").then(async ({ default: mermaid }) => {
+      if (!iconsRegistered) {
+        mermaid.registerIconPacks([
+          {
+            name: "logos",
+            loader: () => import("@iconify-json/logos").then((m) => m.icons),
+          },
+        ])
+        iconsRegistered = true
+      }
+
       mermaid.initialize({
         startOnLoad: false,
         theme: theme === "dark" ? "dark" : "default",
@@ -32,6 +44,15 @@ export function Mermaid({ chart }: MermaidProps) {
         flowchart: { useMaxWidth: false },
         sequence: { useMaxWidth: false },
         c4: { useMaxWidth: false },
+        architecture: { useMaxWidth: false },
+        themeVariables: {
+          // Explicit, high-contrast colors for subgraph/cluster titles —
+          // the built-in dark theme's default clusterBkg is dark enough
+          // to make the title text read as if it had no background at
+          // all against this site's near-black page background.
+          clusterBkg: theme === "dark" ? "#374151" : "#fef9c3",
+          clusterBorder: theme === "dark" ? "#6b7280" : "#ca8a04",
+        },
       })
 
       try {
@@ -55,3 +76,4 @@ export function Mermaid({ chart }: MermaidProps) {
     />
   )
 }
+

--- a/content/event-driven-architecture-from-first-principles.mdx
+++ b/content/event-driven-architecture-from-first-principles.mdx
@@ -77,19 +77,18 @@ The rest of this design is easiest to reason about visually, using the [C4 model
 
 Zoomed all the way out, the system is a single box the customer interacts with, sitting between three external parties it doesn't control:
 
-<Mermaid chart={`C4Context
-    title System Context — Order Fulfillment
-    Person(customer, "Customer", "Places an order in the online store")
-    System(orderSystem, "Order Fulfillment System", "Accepts orders and coordinates payment, inventory, and shipping through domain events")
-    System_Ext(paymentProvider, "Payment Provider", "Authorizes and captures card payments")
-    System_Ext(carrier, "Shipping Carrier", "Picks up and delivers packages")
-    System_Ext(notifyProvider, "Notification Provider", "Delivers transactional email and SMS")
+<Mermaid chart={`flowchart TD
+    customer(["Customer\nPlaces an order in the online store"])
+    orderSystem["Order Fulfillment System\nAccepts orders, coordinates payment,\ninventory, and shipping via events"]
+    paymentProvider[["Payment Provider\nAuthorizes and captures payments"]]
+    carrier[["Shipping Carrier\nPicks up and delivers packages"]]
+    notifyProvider[["Notification Provider\nDelivers transactional email / SMS"]]
 
-    Rel(customer, orderSystem, "Places order, checks status")
-    Rel(orderSystem, paymentProvider, "Authorizes payment", "HTTPS")
-    Rel(orderSystem, carrier, "Requests pickup, receives tracking", "HTTPS")
-    Rel(orderSystem, notifyProvider, "Sends order updates", "HTTPS")
-    Rel(notifyProvider, customer, "Delivers notification", "Email / SMS")
+    customer -- "Places order, checks status" --> orderSystem
+    orderSystem -- "Authorizes payment" --> paymentProvider
+    orderSystem -- "Requests pickup" --> carrier
+    orderSystem -- "Sends order updates" --> notifyProvider
+    notifyProvider -. "Delivers notification" .-> customer
 `} />
 
 Nothing here says "event-driven" yet — this level deliberately doesn't. The Context view exists to answer "what is this system, and who/what does it talk to," not "how is it built." That's on purpose: a stakeholder deciding whether this system needs to integrate with a new carrier shouldn't need to understand choreography vs. orchestration to answer that question.
@@ -98,35 +97,32 @@ Nothing here says "event-driven" yet — this level deliberately doesn't. The Co
 
 One level in, the single box becomes the actual services and the event bus routing messages between them — this is where "event-driven" becomes visible:
 
-<Mermaid chart={`C4Container
-    title Container View — Order Fulfillment System
-    Person(customer, "Customer")
+<Mermaid chart={`flowchart TD
+    customer(["Customer"])
+    paymentProvider[["Payment Provider"]]
+    carrier[["Shipping Carrier"]]
 
-    System_Boundary(order_system, "Order Fulfillment System") {
-        Container(orderSvc, "Order Service", "AWS Lambda", "Accepts orders, publishes OrderPlaced")
-        Container(paymentSvc, "Payment Service", "AWS Lambda", "Authorizes payment, publishes PaymentAuthorized / PaymentFailed")
-        Container(inventorySvc, "Inventory Service", "AWS Lambda", "Reserves stock, publishes InventoryReserved / InventoryRejected")
-        Container(shippingSvc, "Shipping Service", "AWS Lambda", "Books carrier pickup, publishes OrderShipped")
-        Container(notifySvc, "Notification Service", "AWS Lambda", "Sends customer-facing updates")
-        Container(bus, "Event Bus", "Amazon EventBridge", "Routes domain events to every interested consumer")
-        ContainerDb(eventStore, "Event Store", "DynamoDB", "Append-only record of every event, keyed by order id")
-    }
+    subgraph system["Order Fulfillment System"]
+        direction TB
+        orderSvc["Order Service\nAWS Lambda"]
+        bus{{"Event Bus\nAmazon EventBridge"}}
+        paymentSvc["Payment Service\nAWS Lambda"]
+        inventorySvc["Inventory Service\nAWS Lambda"]
+        shippingSvc["Shipping Service\nAWS Lambda"]
+        notifySvc["Notification Service\nAWS Lambda"]
+        eventStore[("Event Store\nDynamoDB")]
 
-    System_Ext(paymentProvider, "Payment Provider")
-    System_Ext(carrier, "Shipping Carrier")
+        orderSvc -- "OrderPlaced" --> bus
+        bus <-- "PaymentAuthorized /\nPaymentFailed" --> paymentSvc
+        bus <-- "InventoryReserved /\nInventoryRejected" --> inventorySvc
+        bus <-- "OrderShipped" --> shippingSvc
+        bus -- "every order event" --> notifySvc
+        bus -. "every event, appended" .-> eventStore
+    end
 
-    Rel(customer, orderSvc, "POST /orders", "HTTPS")
-    Rel(orderSvc, bus, "Publishes OrderPlaced")
-    Rel(bus, paymentSvc, "OrderPlaced")
-    Rel(paymentSvc, paymentProvider, "Authorizes charge", "HTTPS")
-    Rel(paymentSvc, bus, "Publishes PaymentAuthorized / PaymentFailed")
-    Rel(bus, inventorySvc, "PaymentAuthorized")
-    Rel(inventorySvc, bus, "Publishes InventoryReserved / InventoryRejected")
-    Rel(bus, shippingSvc, "InventoryReserved")
-    Rel(shippingSvc, carrier, "Books pickup", "HTTPS")
-    Rel(shippingSvc, bus, "Publishes OrderShipped")
-    Rel(bus, notifySvc, "Every order-facing event")
-    Rel(bus, eventStore, "Every event, appended")
+    customer -- "POST /orders" --> orderSvc
+    paymentSvc -- "Authorizes charge" --> paymentProvider
+    shippingSvc -- "Books pickup" --> carrier
 `} />
 
 Every service is both a producer and a consumer, except Order Service (only produces, it's the entry point) and Notification Service (only consumes, it's the exit point). Nothing calls anything else's HTTP endpoint directly — every arrow that crosses a service boundary goes through the bus. That's the whole point made visible: no service holds a thread open waiting for another one.

--- a/content/event-driven-architecture-from-first-principles.mdx
+++ b/content/event-driven-architecture-from-first-principles.mdx
@@ -1,0 +1,242 @@
+---
+title: "Event-Driven Architecture: Designing an Order Fulfillment System from First Principles"
+description: A synchronous order flow that collapses under load is the easy problem. Designing the event-driven system that replaces it — choreography, compensations, an AWS mapping, and the mental model to reuse on your own domain — is the actual architecture work.
+author: Igor Souza
+date: 2026-08-23
+published: true
+tags: ["architecture", "event-driven", "aws", "distributed-systems", "system-design"]
+---
+
+Picture the most obvious way to build an online store's checkout: a single `POST /orders` handler that, in one request, charges the customer's card, decrements inventory, books a carrier pickup, and sends a confirmation email — four synchronous calls, one after another, all inside the same HTTP request. It works in the demo. Then Black Friday traffic arrives, the carrier's API gets slow, and every request now holds its thread open waiting on a service you don't control and can't speed up. Threads pile up, the request queue backs up behind them, and soon customers whose payment already succeeded are staring at a spinner, because their order is stuck waiting on a shipping label. Worse: if the process crashes between "card charged" and "email sent," nothing remembers that charge ever happened. There's no record, no retry, no way back — just a customer who was billed for an order the system has no memory of.
+
+None of that is a bug in any one line of code. It's what happens when a business process that's inherently a sequence of independent steps, happening over time, gets modeled as one synchronous call stack. This post is about the alternative — not "add a queue somewhere," but designing an event-driven architecture (EDA) for this problem properly, from the ground up: what actually goes wrong with the naive fix, how to build the event model piece by piece, where the business logic lives independent of AWS or Kafka or anything else, and the mental model to carry into your own systems once the diagrams are gone. The domain is order fulfillment — Order Placed → Payment → Inventory → Shipping → Notification — chosen because it's the example nearly every serious treatment of EDA reaches for, from Gregor Hohpe's writing on enterprise integration to Adam Bellemare's *Building Event-Driven Microservices*. If you can reason about this one end to end, the reasoning transfers.
+
+## What actually breaks in a synchronous chain
+
+The checkout handler above has a name for its core defect: **temporal coupling**. Every step is forced to happen at the exact moment the one before it finishes, inside the exact same request, on the exact same thread. That's a much stronger constraint than the business actually needs — nothing about "ship the order" genuinely requires it to happen synchronously, in-line, before the customer's browser gets a response. Shipping can happen a second later, or an hour later; the customer doesn't need to wait for a tracking number to know their order was accepted.
+
+Temporal coupling is what turns "the shipping carrier is having a slow day" into "the whole checkout system is down." Every synchronous dependency in the chain becomes a single point of failure for the entire chain, and the chain is only as fast as its slowest link. This is the actual problem event-driven architecture exists to solve: decouple *when* something happens from *when the thing that triggered it* happened, so a slow or failing step degrades gracefully instead of taking the whole flow down with it.
+
+## The principal issues EDA itself introduces
+
+The instinct, once temporal coupling is named as the enemy, is to reach for a message queue and declare victory. That's necessary, but it's not sufficient — and treating it as sufficient is exactly the trap Gregor Hohpe, co-author of *Enterprise Integration Patterns*, has written about directly. Event-driven systems, he notes, "tend to exhibit an aura of simple elegance," and because they're "modeled after real world events the resulting system model is usually very expressive." That's true, and it's also the danger: "the simple elegance of EDAs can be deceiving," because designing one correctly is often *more* work than the synchronous version it replaces, not less. Publishing events instead of making calls doesn't remove the hard problems of distributed systems — it just moves them somewhere less visible.
+
+Four issues show up in essentially every EDA, and a design that doesn't name them up front will discover them in production instead:
+
+- **Coupling didn't disappear, it moved.** Two services no longer call each other directly, but if the consumer depends on the exact shape of the producer's event, they're still coupled — just through a schema instead of a function signature. Hohpe's point above is precisely this: "loosely coupled" is a design goal EDA makes *possible*, not one it grants automatically.
+- **Consistency becomes eventual, not immediate.** The moment `OrderPlaced` is published, the order exists in "placed" state everywhere except the services that haven't processed that event yet. There is no instant at which the whole system agrees on the order's status — only a window, usually milliseconds, sometimes longer under load, during which different parts of the system have different answers to "is this order paid?"
+- **Ordering and duplication aren't guaranteed for free.** Most brokers guarantee ordering only within a partition or a single stream, not globally, and most deliver *at-least once* — meaning the same event can arrive twice. A consumer that isn't built to handle a duplicate `PaymentAuthorized` will, sooner or later, double-charge something.
+- **A failure has nowhere obvious to go.** In a synchronous call, a failure is a stack trace with a caller waiting for it. In an event-driven flow, a failure is a message a consumer couldn't process — and unless the design explicitly says what happens next, that failure just evaporates, silently, with no one aware anything went wrong.
+
+<Callout icon="⚠️" type="warning">
+None of these four are edge cases to patch later — they're the actual design surface of an event-driven architecture. A plan that only decides "which services publish which events" and treats consistency, ordering, duplication, and failure-handling as implementation details hasn't designed the architecture yet; it's designed the happy path.
+</Callout>
+
+## Building the event model, piece by piece
+
+Start from the business process, not the infrastructure. The order fulfillment flow is a sequence of *facts that became true*, and each one is a candidate event, named in the past tense because an event is something that already happened and can't be un-happened:
+
+1. `OrderPlaced` — a customer submitted an order. This is the only event a synchronous request produces directly; everything after it happens independently.
+2. `PaymentAuthorized` / `PaymentFailed` — the payment provider approved or declined the charge.
+3. `InventoryReserved` / `InventoryRejected` — stock was set aside for the order, or there wasn't enough.
+4. `OrderShipped` — the carrier picked up the package.
+5. `OrderDelivered` — the carrier confirms drop-off (published by the carrier's own webhook, arriving whenever it arrives).
+
+Each event carries only what the *next* step needs to act — an order ID, the fields relevant to that step, and a correlation identifier tying every event for one order back together — not a dump of the entire order object. That restraint matters: an event with too much data becomes a second API contract nobody agreed to, and every field a consumer starts relying on is a field the producer can no longer change without breaking someone downstream.
+
+### Choreography or orchestration — and why this design picks one
+
+Once the events exist, something has to decide what triggers what. There are two well-established shapes for that, both named and analyzed in depth by Chris Richardson's work on the saga pattern for distributed transactions:
+
+- **Choreography**: every service reacts to events on its own. Payment Service listens for `OrderPlaced`; Inventory Service listens for `PaymentAuthorized`; nothing sits in the middle telling anyone what to do next. The flow *emerges* from each service's own subscriptions.
+- **Orchestration**: a central coordinator (Richardson calls it a saga orchestrator) explicitly calls each service in turn and tracks the state of the whole flow itself.
+
+For this system, **choreography is the right call**, for a specific reason: the order fulfillment flow has no step that needs to make a decision based on the *whole* flow's state — each service only ever needs to know about the one event immediately before it. There's no branching logic like "if the customer is a VIP, skip inventory reservation and orchestrate a rush order" that would need a central brain watching everything at once. Adam Bellemare's *Building Event-Driven Microservices* makes the same call for this class of problem: choreography keeps each service's logic local and lets services be added or removed from the flow without touching a central coordinator's code. The tradeoff, and it's real, is observability — nothing shows you the whole flow's state in one place, which is why the event store described below exists.
+
+<Card>
+**When would this design switch to orchestration instead?**
+
+The moment a step needs conditional branching that depends on more than the immediately preceding event — "if payment took longer than 30 seconds, cancel instead of waiting," "if this is a split shipment, wait for all parts before notifying" — that logic needs somewhere to live that can see the whole flow's state at once. That's exactly what an orchestrator is for. Don't retrofit that logic into a maze of choreographed listeners each guessing at global state from a local event; introduce an orchestrator (AWS Step Functions is a natural fit here, see the AWS mapping below) for that one flow, and let the rest of the system keep choreographing.
+</Card>
+
+## The business layer that doesn't know AWS exists
+
+Everything above — the five events, the choreography decision, the rule that payment must precede inventory reservation — is a business decision, not a technology one. It should be possible to describe the entire flow to a domain expert who has never heard of EventBridge, and it should be possible to unit-test every one of these rules without a broker, a queue, or a network connection anywhere in sight. That's the same discipline this blog covered in [Domain-Driven Design: Architecture That Grows with Your Business](/domain-driven-design-architecture-that-grows-with-your-business): a domain layer that has zero imports from any framework or infrastructure library, expressing "what a valid order looks like" and "what happens after payment succeeds" as plain business logic.
+
+In this architecture, that means:
+
+- **Domain events are domain objects.** `OrderPlaced`, `PaymentAuthorized`, and the rest are defined in the domain layer as plain data, with no dependency on EventBridge's SDK, Kafka's client library, or any serialization format tied to a specific broker.
+- **The domain decides *what* to publish; the infrastructure decides *how*.** A `PlaceOrder` use case in the application layer asks the domain to validate and create an order, and the domain returns (or raises) the fact that `OrderPlaced` happened. Only the infrastructure layer knows how to actually put that fact on a bus.
+- **Swapping EventBridge for Kafka, or Kafka for SNS+SQS, should never touch the domain layer.** If changing the broker means editing business logic, the boundary was drawn in the wrong place.
+
+This is also what makes the choreography decision above safe to revisit later: because no domain rule depends on *how* an event physically moves between services, migrating from choreography to a Step Functions orchestrator for one specific flow is an infrastructure and application-layer change, not a rewrite of what "a valid order" means.
+
+## The architecture, drawn — full view first
+
+The rest of this design is easiest to reason about visually, using the [C4 model](https://c4model.com), Simon Brown's now-standard notation for describing software architecture at different levels of zoom: Context (who talks to the system, from the outside), Container (what the system is actually made of), and, for a single container, Component. Two levels are enough for this design.
+
+Zoomed all the way out, the system is a single box the customer interacts with, sitting between three external parties it doesn't control:
+
+<Mermaid chart={`C4Context
+    title System Context — Order Fulfillment
+    Person(customer, "Customer", "Places an order in the online store")
+    System(orderSystem, "Order Fulfillment System", "Accepts orders and coordinates payment, inventory, and shipping through domain events")
+    System_Ext(paymentProvider, "Payment Provider", "Authorizes and captures card payments")
+    System_Ext(carrier, "Shipping Carrier", "Picks up and delivers packages")
+    System_Ext(notifyProvider, "Notification Provider", "Delivers transactional email and SMS")
+
+    Rel(customer, orderSystem, "Places order, checks status")
+    Rel(orderSystem, paymentProvider, "Authorizes payment", "HTTPS")
+    Rel(orderSystem, carrier, "Requests pickup, receives tracking", "HTTPS")
+    Rel(orderSystem, notifyProvider, "Sends order updates", "HTTPS")
+    Rel(notifyProvider, customer, "Delivers notification", "Email / SMS")
+`} />
+
+Nothing here says "event-driven" yet — this level deliberately doesn't. The Context view exists to answer "what is this system, and who/what does it talk to," not "how is it built." That's on purpose: a stakeholder deciding whether this system needs to integrate with a new carrier shouldn't need to understand choreography vs. orchestration to answer that question.
+
+## Zoomed in — the containers and the events between them
+
+One level in, the single box becomes the actual services and the event bus routing messages between them — this is where "event-driven" becomes visible:
+
+<Mermaid chart={`C4Container
+    title Container View — Order Fulfillment System
+    Person(customer, "Customer")
+
+    System_Boundary(order_system, "Order Fulfillment System") {
+        Container(orderSvc, "Order Service", "AWS Lambda", "Accepts orders, publishes OrderPlaced")
+        Container(paymentSvc, "Payment Service", "AWS Lambda", "Authorizes payment, publishes PaymentAuthorized / PaymentFailed")
+        Container(inventorySvc, "Inventory Service", "AWS Lambda", "Reserves stock, publishes InventoryReserved / InventoryRejected")
+        Container(shippingSvc, "Shipping Service", "AWS Lambda", "Books carrier pickup, publishes OrderShipped")
+        Container(notifySvc, "Notification Service", "AWS Lambda", "Sends customer-facing updates")
+        Container(bus, "Event Bus", "Amazon EventBridge", "Routes domain events to every interested consumer")
+        ContainerDb(eventStore, "Event Store", "DynamoDB", "Append-only record of every event, keyed by order id")
+    }
+
+    System_Ext(paymentProvider, "Payment Provider")
+    System_Ext(carrier, "Shipping Carrier")
+
+    Rel(customer, orderSvc, "POST /orders", "HTTPS")
+    Rel(orderSvc, bus, "Publishes OrderPlaced")
+    Rel(bus, paymentSvc, "OrderPlaced")
+    Rel(paymentSvc, paymentProvider, "Authorizes charge", "HTTPS")
+    Rel(paymentSvc, bus, "Publishes PaymentAuthorized / PaymentFailed")
+    Rel(bus, inventorySvc, "PaymentAuthorized")
+    Rel(inventorySvc, bus, "Publishes InventoryReserved / InventoryRejected")
+    Rel(bus, shippingSvc, "InventoryReserved")
+    Rel(shippingSvc, carrier, "Books pickup", "HTTPS")
+    Rel(shippingSvc, bus, "Publishes OrderShipped")
+    Rel(bus, notifySvc, "Every order-facing event")
+    Rel(bus, eventStore, "Every event, appended")
+`} />
+
+Every service is both a producer and a consumer, except Order Service (only produces, it's the entry point) and Notification Service (only consumes, it's the exit point). Nothing calls anything else's HTTP endpoint directly — every arrow that crosses a service boundary goes through the bus. That's the whole point made visible: no service holds a thread open waiting for another one.
+
+## Following one order through the flow
+
+The container diagram shows *what can talk to what*; it doesn't show the order the events actually happen in for one specific order. That's what a sequence diagram is for — the happy path first:
+
+<Mermaid chart={`sequenceDiagram
+    participant C as Customer
+    participant O as Order Service
+    participant Bus as Event Bus
+    participant P as Payment Service
+    participant I as Inventory Service
+    participant S as Shipping Service
+    participant N as Notification Service
+
+    C->>O: Place order
+    O->>Bus: OrderPlaced
+    Bus->>P: OrderPlaced
+    P->>Bus: PaymentAuthorized
+    Bus->>I: PaymentAuthorized
+    I->>Bus: InventoryReserved
+    Bus->>S: InventoryReserved
+    S->>Bus: OrderShipped
+    Bus->>N: OrderShipped
+    N-->>C: "Your order has shipped"
+`} />
+
+Notice what the customer's original request actually waits for: just `O->>Bus: OrderPlaced`. Everything after that happens outside the request/response cycle entirely. The customer gets an immediate "order accepted" response, and the rest of the diagram plays out over however long it actually takes — seconds, usually, but nothing breaks if the carrier takes an hour to confirm pickup.
+
+Now the path that actually justifies calling this a *design*, not just a happy-path diagram — what happens when a step fails after an earlier one already succeeded:
+
+<Mermaid chart={`sequenceDiagram
+    participant O as Order Service
+    participant Bus as Event Bus
+    participant P as Payment Service
+    participant I as Inventory Service
+    participant N as Notification Service
+
+    O->>Bus: OrderPlaced
+    Bus->>P: OrderPlaced
+    P->>Bus: PaymentAuthorized
+    Bus->>I: PaymentAuthorized
+    I->>Bus: InventoryRejected (out of stock)
+    Bus->>P: InventoryRejected
+    P->>P: Compensate: refund the authorization
+    P->>Bus: PaymentRefunded
+    Bus->>N: InventoryRejected
+    N-->>O: "Sorry — item unavailable, refund issued"
+`} />
+
+Payment already succeeded by the time Inventory discovers the item is out of stock. There's no database transaction spanning both services to roll back — that's not available across service boundaries in this architecture, and pretending otherwise is how EDAs quietly turn into distributed monoliths. Instead, Payment Service subscribes to `InventoryRejected` specifically so it can run a **compensating action**: not undoing history (the charge really did happen), but publishing a new fact, `PaymentRefunded`, that corrects it going forward. This is the saga pattern's actual mechanism, and it's the reason every service in a choreographed saga needs to know not just what it produces, but what failure events elsewhere it needs to *react* to.
+
+<Callout icon="💡" type="informative">
+Design every event-producing step with its compensating action decided at the same time, not as an afterthought. "What happens if this step succeeds but a later one fails?" is a question with a concrete, nameable answer for every step here — `PaymentRefunded`, `InventoryReleased`, a cancellation notice — and if a step doesn't have one yet, the design isn't finished, even if the happy-path diagram looks complete.
+</Callout>
+
+## Mapping the design onto AWS
+
+Nothing above names a specific vendor by accident until now — the container diagram already picked concrete AWS services, and here's the reasoning behind each choice, plus the alternatives that were considered and set aside for this scale:
+
+| Conceptual piece | AWS service | Why this one |
+|---|---|---|
+| Event bus | **Amazon EventBridge** | Built-in schema-based routing rules mean each service subscribes declaratively to the event *types* it cares about, with no consumer group or partition management to run yourself. Kafka on MSK is the better call once throughput or replay requirements grow past what EventBridge is built for — but that's a scaling decision to make later, not a starting assumption. |
+| Service compute | **AWS Lambda** | Each service here reacts to one event type and does bounded, short work — the textbook Lambda shape. Fargate becomes the better fit the moment a service needs to hold long-lived state in memory or run continuously regardless of event volume. |
+| Saga orchestration (for flows that need it) | **AWS Step Functions** | Named explicitly in the choreography-vs-orchestration callout above: the one place in this design where a flow needs to see its whole state at once, Step Functions gives that without hand-rolling a state machine. |
+| Event store / audit log | **Amazon DynamoDB** | An append-only table keyed by order ID answers "what happened to this order, in order" — the one thing choreography's decentralization makes hard to see anywhere else. Cheap to write to, and TTL support lets old orders age out automatically if the business doesn't need indefinite retention. |
+| Dead-letter handling | **Amazon SQS (DLQ)** | EventBridge rules can target an SQS dead-letter queue directly when a consumer repeatedly fails to process an event, so a stuck message becomes a visible, alertable queue depth instead of a silently dropped event. |
+| Observability | **CloudWatch + AWS X-Ray** | X-Ray traces a correlation ID across every Lambda invocation the event triggers, reconstructing the sequence-diagram-shaped flow above from real production traffic — the closest thing choreography has to the orchestrator's built-in visibility. |
+
+<Card>
+**Why not just use Kafka from day one, since so much EDA literature is Kafka-first?**
+
+Ben Stopford's *Designing Event-Driven Systems* — written from inside Confluent, the company behind Kafka — makes a strong case for Kafka specifically when a system needs event *replay*, long retention, or very high throughput fan-out to many consumers. Nothing in this order-fulfillment design needs any of those yet: five services, one event per order per step, no requirement to replay six months of history to rebuild a read model. Reaching for Kafka (and the operational cost of running or managing it) before the design actually needs replay or throughput at that scale is optimizing for a problem this system doesn't have. EventBridge is the deliberately smaller starting point; migrating the event bus later doesn't touch the domain layer, per the business-layer section above.
+</Card>
+
+## The mental model to keep
+
+Diagrams describe this one system. The mental model below is what's meant to survive past this specific order-fulfillment example and apply to whatever event-driven system gets designed next:
+
+| If this happens... | Do this | Not this |
+|---|---|---|
+| A consumer fails to process an event after retries | Route to a dead-letter queue and alert | Silently drop it, or retry forever and hide the failure |
+| Two services need the same data | Publish it as an event; let each own its own copy | Have one service call the other synchronously to fetch it |
+| A step succeeds but a later step in the same flow fails | Fire a named compensating event, decided at design time | Try to roll back across service boundaries with a distributed transaction |
+| A screen needs a strongly consistent, "right now" read | Build a dedicated read model (CQRS) fed by the events | Query the event log directly on every page load |
+| The same event might be delivered twice | Design every consumer to be idempotent (dedupe by event ID) | Assume "exactly once" and get surprised in production |
+| A flow needs a decision based on more than the immediately preceding event | Introduce an orchestrator for *that* flow | Chain conditional logic across choreographed listeners guessing at global state |
+| You're not sure whether two things are the "same" event or two different ones | Ask whether the business would describe them as one sentence or two | Merge them because it's fewer message types to define |
+
+## Why this way and not another — the actual design log
+
+Three decisions above deserve to be named explicitly as decisions, because a reader building their own system will face the same forks:
+
+- **Choreography over orchestration.** Chosen because no step here needs global flow state to make a local decision — see the choreography section above. This is a call specific to this domain's shape, not a universal preference; a flow with real branching logic would tip the other way, and that's fine — Step Functions is already in the toolbox for exactly that.
+- **EventBridge over Kafka.** Chosen for this scale and this lack of a replay requirement, per the AWS mapping section — not because Kafka is worse, but because it solves problems (replay, extreme fan-out, long retention) this design doesn't have yet.
+- **An explicit event store, even with choreography's decentralization.** Choreography's whole appeal is that no central piece needs to know about the whole flow — but that's also its cost: nothing shows you the whole flow's state in one place. The DynamoDB event store exists specifically to pay that cost back, on the observability side, without giving up the decoupling on the execution side.
+
+None of these are the *only* correct answers — they're the correct answers for a five-service order fulfillment flow with no complex branching, moderate throughput, and no replay requirement. Change any of those constraints and at least one of these three decisions should change with them. That's the actual skill this post is trying to hand off: not "here is the event-driven architecture," but the reasoning that produces one for whatever domain comes next.
+
+### Further Reading
+
+- [Gregor Hohpe — "Event-driven = Loosely coupled? Not so fast!"](https://www.enterpriseintegrationpatterns.com/ramblings/eventdriven_coupling.html)
+- Gregor Hohpe & Bobby Woolf, *Enterprise Integration Patterns* (Addison-Wesley, 2003)
+- Ben Stopford, *Designing Event-Driven Systems* (O'Reilly / Confluent, 2018)
+- Adam Bellemare, *Building Event-Driven Microservices* (O'Reilly, 2020)
+- [Chris Richardson — The Saga Pattern](https://microservices.io/patterns/data/saga.html)
+- [Martin Fowler — "What do you mean by Event-Driven?"](https://martinfowler.com/articles/201701-event-driven.html)
+- [Simon Brown — The C4 Model for Software Architecture](https://c4model.com)
+- [Mermaid — C4 Diagrams](https://mermaid.js.org/syntax/c4.html)
+- [Amazon EventBridge documentation](https://docs.aws.amazon.com/eventbridge/)
+- [AWS Step Functions documentation](https://docs.aws.amazon.com/step-functions/)

--- a/content/event-driven-architecture-from-first-principles.mdx
+++ b/content/event-driven-architecture-from-first-principles.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Event-Driven Architecture: Designing an Order Fulfillment System from First Principles"
-description: A synchronous order flow that collapses under load is the easy problem. Designing the event-driven system that replaces it — choreography, compensations, an AWS mapping, and the mental model to reuse on your own domain — is the actual architecture work.
+description: The simplest event-driven design is never the finished one. This post builds an order fulfillment system iteration by iteration — each one fixing a concrete failure the last couldn't — from a synchronous handler to a production-ready, choreographed architecture.
 author: Igor Souza
 date: 2026-08-23
 published: true
@@ -9,73 +9,38 @@ tags: ["architecture", "event-driven", "aws", "distributed-systems", "system-des
 
 Picture the most obvious way to build an online store's checkout: a single `POST /orders` handler that, in one request, charges the customer's card, decrements inventory, books a carrier pickup, and sends a confirmation email — four synchronous calls, one after another, all inside the same HTTP request. It works in the demo. Then Black Friday traffic arrives, the carrier's API gets slow, and every request now holds its thread open waiting on a service you don't control and can't speed up. Threads pile up, the request queue backs up behind them, and soon customers whose payment already succeeded are staring at a spinner, because their order is stuck waiting on a shipping label. Worse: if the process crashes between "card charged" and "email sent," nothing remembers that charge ever happened. There's no record, no retry, no way back — just a customer who was billed for an order the system has no memory of.
 
-None of that is a bug in any one line of code. It's what happens when a business process that's inherently a sequence of independent steps, happening over time, gets modeled as one synchronous call stack. This post is about the alternative — not "add a queue somewhere," but designing an event-driven architecture (EDA) for this problem properly, from the ground up: what actually goes wrong with the naive fix, how to build the event model piece by piece, where the business logic lives independent of AWS or Kafka or anything else, and the mental model to carry into your own systems once the diagrams are gone. The domain is order fulfillment — Order Placed → Payment → Inventory → Shipping → Notification — chosen because it's the example nearly every serious treatment of EDA reaches for, from Gregor Hohpe's writing on enterprise integration to Adam Bellemare's *Building Event-Driven Microservices*. If you can reason about this one end to end, the reasoning transfers.
+None of that is a bug in any one line of code. It's what happens when a business process that's inherently a sequence of independent steps, happening over time, gets modeled as one synchronous call stack. This post doesn't jump straight to the finished architecture — it builds toward it the way you'd actually have to: start from this synchronous baseline, add exactly the piece needed to fix whatever it breaks on next, and stop the moment the result actually holds up. Four iterations get from here to a production-ready, event-driven design, each one earning its complexity by fixing something the previous iteration genuinely couldn't. The domain is order fulfillment — Order Placed → Payment → Inventory → Shipping → Notification — chosen because it's the example nearly every serious treatment of EDA reaches for, from Gregor Hohpe's writing on enterprise integration to Adam Bellemare's *Building Event-Driven Microservices*. If you can reason about this one end to end, the reasoning transfers.
 
-## What actually breaks in a synchronous chain
+## Iteration 0 — name the baseline
+
+Before fixing the synchronous handler above, it's worth drawing it. The point of iteration 0 isn't to solve anything — just to be honest about what's actually there, so every later diagram can be judged against it:
+
+<Mermaid chart={`flowchart LR
+    customer(["Customer"])
+    response(["Response"])
+
+    subgraph request["One HTTP request, one thread"]
+        direction LR
+        charge["Charge card"] --> reserve["Reserve stock"] --> book["Book carrier pickup"] --> email["Send confirmation email"]
+    end
+
+    customer -- "POST /orders" --> charge
+    email --> response
+`} />
 
 The checkout handler above has a name for its core defect: **temporal coupling**. Every step is forced to happen at the exact moment the one before it finishes, inside the exact same request, on the exact same thread. That's a much stronger constraint than the business actually needs — nothing about "ship the order" genuinely requires it to happen synchronously, in-line, before the customer's browser gets a response. Shipping can happen a second later, or an hour later; the customer doesn't need to wait for a tracking number to know their order was accepted.
 
 Temporal coupling is what turns "the shipping carrier is having a slow day" into "the whole checkout system is down." Every synchronous dependency in the chain becomes a single point of failure for the entire chain, and the chain is only as fast as its slowest link. This is the actual problem event-driven architecture exists to solve: decouple *when* something happens from *when the thing that triggered it* happened, so a slow or failing step degrades gracefully instead of taking the whole flow down with it.
 
-## The principal issues EDA itself introduces
+## One rule that holds through every iteration below
 
-The instinct, once temporal coupling is named as the enemy, is to reach for a message queue and declare victory. That's necessary, but it's not sufficient — and treating it as sufficient is exactly the trap Gregor Hohpe, co-author of *Enterprise Integration Patterns*, has written about directly. Event-driven systems, he notes, "tend to exhibit an aura of simple elegance," and because they're "modeled after real world events the resulting system model is usually very expressive." That's true, and it's also the danger: "the simple elegance of EDAs can be deceiving," because designing one correctly is often *more* work than the synchronous version it replaces, not less. Publishing events instead of making calls doesn't remove the hard problems of distributed systems — it just moves them somewhere less visible.
+One thing gets decided now and never revisited by any iteration that follows: the business rules — what events exist, what order they happen in, what a valid order looks like — live in a domain layer that has never heard of AWS. That's the same discipline this blog covered in [Domain-Driven Design: Architecture That Grows with Your Business](/domain-driven-design-architecture-that-grows-with-your-business): domain events are domain objects, with zero imports from EventBridge's SDK, Kafka's client library, or any broker-specific serialization format; the domain decides *what* fact just became true, and only the infrastructure layer decides *how* that fact gets put on a bus.
 
-Four issues show up in essentially every EDA, and a design that doesn't name them up front will discover them in production instead:
+Every iteration below changes infrastructure — what publishes to what, what gets added to handle a new failure mode — and none of them should ever require touching what "a valid order" means. If migrating from choreography to an orchestrator, or from EventBridge to Kafka, means editing business logic, the boundary was drawn in the wrong place.
 
-- **Coupling didn't disappear, it moved.** Two services no longer call each other directly, but if the consumer depends on the exact shape of the producer's event, they're still coupled — just through a schema instead of a function signature. Hohpe's point above is precisely this: "loosely coupled" is a design goal EDA makes *possible*, not one it grants automatically.
-- **Consistency becomes eventual, not immediate.** The moment `OrderPlaced` is published, the order exists in "placed" state everywhere except the services that haven't processed that event yet. There is no instant at which the whole system agrees on the order's status — only a window, usually milliseconds, sometimes longer under load, during which different parts of the system have different answers to "is this order paid?"
-- **Ordering and duplication aren't guaranteed for free.** Most brokers guarantee ordering only within a partition or a single stream, not globally, and most deliver *at-least once* — meaning the same event can arrive twice. A consumer that isn't built to handle a duplicate `PaymentAuthorized` will, sooner or later, double-charge something.
-- **A failure has nowhere obvious to go.** In a synchronous call, a failure is a stack trace with a caller waiting for it. In an event-driven flow, a failure is a message a consumer couldn't process — and unless the design explicitly says what happens next, that failure just evaporates, silently, with no one aware anything went wrong.
+## The outside view doesn't change
 
-<Callout icon="⚠️" type="warning">
-None of these four are edge cases to patch later — they're the actual design surface of an event-driven architecture. A plan that only decides "which services publish which events" and treats consistency, ordering, duplication, and failure-handling as implementation details hasn't designed the architecture yet; it's designed the happy path.
-</Callout>
-
-## Building the event model, piece by piece
-
-Start from the business process, not the infrastructure. The order fulfillment flow is a sequence of *facts that became true*, and each one is a candidate event, named in the past tense because an event is something that already happened and can't be un-happened:
-
-1. `OrderPlaced` — a customer submitted an order. This is the only event a synchronous request produces directly; everything after it happens independently.
-2. `PaymentAuthorized` / `PaymentFailed` — the payment provider approved or declined the charge.
-3. `InventoryReserved` / `InventoryRejected` — stock was set aside for the order, or there wasn't enough.
-4. `OrderShipped` — the carrier picked up the package.
-5. `OrderDelivered` — the carrier confirms drop-off (published by the carrier's own webhook, arriving whenever it arrives).
-
-Each event carries only what the *next* step needs to act — an order ID, the fields relevant to that step, and a correlation identifier tying every event for one order back together — not a dump of the entire order object. That restraint matters: an event with too much data becomes a second API contract nobody agreed to, and every field a consumer starts relying on is a field the producer can no longer change without breaking someone downstream.
-
-### Choreography or orchestration — and why this design picks one
-
-Once the events exist, something has to decide what triggers what. There are two well-established shapes for that, both named and analyzed in depth by Chris Richardson's work on the saga pattern for distributed transactions:
-
-- **Choreography**: every service reacts to events on its own. Payment Service listens for `OrderPlaced`; Inventory Service listens for `PaymentAuthorized`; nothing sits in the middle telling anyone what to do next. The flow *emerges* from each service's own subscriptions.
-- **Orchestration**: a central coordinator (Richardson calls it a saga orchestrator) explicitly calls each service in turn and tracks the state of the whole flow itself.
-
-For this system, **choreography is the right call**, for a specific reason: the order fulfillment flow has no step that needs to make a decision based on the *whole* flow's state — each service only ever needs to know about the one event immediately before it. There's no branching logic like "if the customer is a VIP, skip inventory reservation and orchestrate a rush order" that would need a central brain watching everything at once. Adam Bellemare's *Building Event-Driven Microservices* makes the same call for this class of problem: choreography keeps each service's logic local and lets services be added or removed from the flow without touching a central coordinator's code. The tradeoff, and it's real, is observability — nothing shows you the whole flow's state in one place, which is why the event store described below exists.
-
-<Card>
-**When would this design switch to orchestration instead?**
-
-The moment a step needs conditional branching that depends on more than the immediately preceding event — "if payment took longer than 30 seconds, cancel instead of waiting," "if this is a split shipment, wait for all parts before notifying" — that logic needs somewhere to live that can see the whole flow's state at once. That's exactly what an orchestrator is for. Don't retrofit that logic into a maze of choreographed listeners each guessing at global state from a local event; introduce an orchestrator (AWS Step Functions is a natural fit here, see the AWS mapping below) for that one flow, and let the rest of the system keep choreographing.
-</Card>
-
-## The business layer that doesn't know AWS exists
-
-Everything above — the five events, the choreography decision, the rule that payment must precede inventory reservation — is a business decision, not a technology one. It should be possible to describe the entire flow to a domain expert who has never heard of EventBridge, and it should be possible to unit-test every one of these rules without a broker, a queue, or a network connection anywhere in sight. That's the same discipline this blog covered in [Domain-Driven Design: Architecture That Grows with Your Business](/domain-driven-design-architecture-that-grows-with-your-business): a domain layer that has zero imports from any framework or infrastructure library, expressing "what a valid order looks like" and "what happens after payment succeeds" as plain business logic.
-
-In this architecture, that means:
-
-- **Domain events are domain objects.** `OrderPlaced`, `PaymentAuthorized`, and the rest are defined in the domain layer as plain data, with no dependency on EventBridge's SDK, Kafka's client library, or any serialization format tied to a specific broker.
-- **The domain decides *what* to publish; the infrastructure decides *how*.** A `PlaceOrder` use case in the application layer asks the domain to validate and create an order, and the domain returns (or raises) the fact that `OrderPlaced` happened. Only the infrastructure layer knows how to actually put that fact on a bus.
-- **Swapping EventBridge for Kafka, or Kafka for SNS+SQS, should never touch the domain layer.** If changing the broker means editing business logic, the boundary was drawn in the wrong place.
-
-This is also what makes the choreography decision above safe to revisit later: because no domain rule depends on *how* an event physically moves between services, migrating from choreography to a Step Functions orchestrator for one specific flow is an infrastructure and application-layer change, not a rewrite of what "a valid order" means.
-
-## The architecture, drawn — full view first
-
-The rest of this design is easiest to reason about visually, using the [C4 model](https://c4model.com), Simon Brown's now-standard notation for describing software architecture at different levels of zoom: Context (who talks to the system, from the outside), Container (what the system is actually made of), and, for a single container, Component. Two levels are enough for this design.
-
-Zoomed all the way out, the system is a single box the customer interacts with, sitting between three external parties it doesn't control:
+Every iteration below changes what's happening *inside* the system. Nothing changes about what's happening at its edge — and that's worth drawing once, using the [C4 model](https://c4model.com), Simon Brown's now-standard notation for describing software architecture at different levels of zoom. This is the Context view: who talks to the system, from the outside, before any internal decision has been made yet:
 
 <Mermaid chart={`flowchart TD
     customer(["Customer\nPlaces an order in the online store"])
@@ -91,11 +56,149 @@ Zoomed all the way out, the system is a single box the customer interacts with, 
     notifyProvider -. "Delivers notification" .-> customer
 `} />
 
-Nothing here says "event-driven" yet — this level deliberately doesn't. The Context view exists to answer "what is this system, and who/what does it talk to," not "how is it built." That's on purpose: a stakeholder deciding whether this system needs to integrate with a new carrier shouldn't need to understand choreography vs. orchestration to answer that question.
+Customer, payment provider, carrier, notification provider — none of that changes no matter which iteration below the system is currently on. Everything from here zooms into the *Container* view: what the system is actually made of, which is exactly what each iteration is about to change.
 
-## Zoomed in — the containers and the events between them
+## Iteration 1 — decouple with events
 
-One level in, the single box becomes the actual services and the event bus routing messages between them — this is where "event-driven" becomes visible:
+The obvious fix for temporal coupling is: stop making synchronous calls, publish facts instead. Start from the business process, not the infrastructure — the order fulfillment flow is a sequence of *facts that became true*, and each one is a candidate event, named in the past tense because an event is something that already happened and can't be un-happened:
+
+1. `OrderPlaced` — a customer submitted an order. This is the only event a synchronous request produces directly; everything after it happens independently.
+2. `PaymentAuthorized` / `PaymentFailed` — the payment provider approved or declined the charge.
+3. `InventoryReserved` / `InventoryRejected` — stock was set aside for the order, or there wasn't enough.
+4. `OrderShipped` — the carrier picked up the package.
+5. `OrderDelivered` — the carrier confirms drop-off (published by the carrier's own webhook, arriving whenever it arrives).
+
+Each event carries only what the *next* step needs to act — an order ID, the fields relevant to that step, and a correlation identifier tying every event for one order back together — not a dump of the entire order object. That restraint matters: an event with too much data becomes a second API contract nobody agreed to, and every field a consumer starts relying on is a field the producer can no longer change without breaking someone downstream.
+
+Wire those events through a bus and this iteration's design already looks nothing like iteration 0's straight line:
+
+<Mermaid chart={`flowchart TD
+    customer(["Customer"])
+    paymentProvider[["Payment Provider"]]
+    carrier[["Shipping Carrier"]]
+
+    subgraph system["Order Fulfillment System"]
+        direction TB
+        orderSvc["Order Service\nAWS Lambda"]
+        bus{{"Event Bus\nAmazon EventBridge"}}
+        paymentSvc["Payment Service\nAWS Lambda"]
+        inventorySvc["Inventory Service\nAWS Lambda"]
+        shippingSvc["Shipping Service\nAWS Lambda"]
+        notifySvc["Notification Service\nAWS Lambda"]
+
+        orderSvc -- "OrderPlaced" --> bus
+        bus <-- "PaymentAuthorized /\nPaymentFailed" --> paymentSvc
+        bus <-- "InventoryReserved /\nInventoryRejected" --> inventorySvc
+        bus <-- "OrderShipped" --> shippingSvc
+        bus -- "every order event" --> notifySvc
+    end
+
+    customer -- "POST /orders" --> orderSvc
+    paymentSvc -- "Authorizes charge" --> paymentProvider
+    shippingSvc -- "Books pickup" --> carrier
+`} />
+
+This already fixes iteration 0's Black Friday problem. Notice what the customer's original request now waits for: just publishing `OrderPlaced`. Everything after that happens outside the request/response cycle entirely, on whatever service reacts to it. Here's one order flowing through this design, happy path:
+
+<Mermaid chart={`sequenceDiagram
+    participant C as Customer
+    participant O as Order Service
+    participant Bus as Event Bus
+    participant P as Payment Service
+    participant I as Inventory Service
+    participant S as Shipping Service
+    participant N as Notification Service
+
+    C->>O: Place order
+    O->>Bus: OrderPlaced
+    Bus->>P: OrderPlaced
+    P->>Bus: PaymentAuthorized
+    Bus->>I: PaymentAuthorized
+    I->>Bus: InventoryReserved
+    Bus->>S: InventoryReserved
+    S->>Bus: OrderShipped
+    Bus->>N: OrderShipped
+    N-->>C: "Your order has shipped"
+`} />
+
+The customer gets an immediate "order accepted" response, and the rest plays out over however long it actually takes — nothing breaks if the carrier takes an hour to confirm pickup, the way it would have in iteration 0.
+
+### What iteration 1 doesn't solve yet
+
+The instinct here is to declare victory — decoupled, no more thread starvation, done. That's exactly the trap Gregor Hohpe, co-author of *Enterprise Integration Patterns*, has written about directly. Event-driven systems, he notes, "tend to exhibit an aura of simple elegance," and because they're "modeled after real world events the resulting system model is usually very expressive." That's true, and it's also the danger: "the simple elegance of EDAs can be deceiving," because designing one correctly is often *more* work than the synchronous version it replaces, not less.
+
+Four issues are already sitting inside iteration 1, waiting to show up in production:
+
+- **Coupling didn't disappear, it moved.** Two services no longer call each other directly, but if a consumer depends on the exact shape of a producer's event, they're still coupled — just through a schema instead of a function signature. Hohpe's point above is precisely this: "loosely coupled" is a design goal EDA makes *possible*, not one it grants automatically. No iteration below removes this — it's a standing tradeoff every event schema change has to respect, not a bug to patch out.
+- **Consistency becomes eventual, not immediate.** The moment `OrderPlaced` is published, the order exists in "placed" state everywhere except the services that haven't processed that event yet. No iteration below removes this either — it's accepted, and the escape hatch (a dedicated, strongly consistent read model, i.e. CQRS) shows up in the mental model at the end, not as a design iteration of its own.
+- **Ordering and duplication aren't guaranteed for free.** Most brokers deliver *at-least once* — meaning the same event can arrive twice. A consumer that isn't built to handle a duplicate `PaymentAuthorized` will, sooner or later, double-charge something. **Iteration 3 exists specifically to fix this.**
+- **A failure has nowhere obvious to go.** In a synchronous call, a failure is a stack trace with a caller waiting for it. In an event-driven flow, unless something explicitly decides what happens next, a failure just evaporates. **Iteration 2 exists specifically to fix this.**
+
+<Callout icon="⚠️" type="warning">
+Two of these four are permanent tradeoffs, not defects — no amount of further iteration removes coupling-through-schema or eventual consistency, it only manages them. Confusing "iterate until every EDA property disappears" with "iterate until the properties that are actually fixable are fixed, and treat the rest as deliberate" is how designs either stall forever chasing an impossible target, or ship pretending they addressed tradeoffs they never actually did.
+</Callout>
+
+## Iteration 2 — handle partial failure with compensating actions
+
+Something has to decide what triggers what, and — separately — what happens when a step downstream fails after an upstream step already succeeded. Both questions get answered by this iteration.
+
+### Choreography or orchestration — and why this design picks one
+
+There are two well-established shapes for deciding what triggers what, both named and analyzed in depth by Chris Richardson's work on the saga pattern for distributed transactions:
+
+- **Choreography**: every service reacts to events on its own. Payment Service listens for `OrderPlaced`; Inventory Service listens for `PaymentAuthorized`; nothing sits in the middle telling anyone what to do next. The flow *emerges* from each service's own subscriptions.
+- **Orchestration**: a central coordinator (Richardson calls it a saga orchestrator) explicitly calls each service in turn and tracks the state of the whole flow itself.
+
+For this system, **choreography is the right call**, for a specific reason: the order fulfillment flow has no step that needs to make a decision based on the *whole* flow's state — each service only ever needs to know about the one event immediately before it. There's no branching logic like "if the customer is a VIP, skip inventory reservation and orchestrate a rush order" that would need a central brain watching everything at once. Adam Bellemare's *Building Event-Driven Microservices* makes the same call for this class of problem: choreography keeps each service's logic local and lets services be added or removed from the flow without touching a central coordinator's code. The tradeoff, and it's real, is observability — nothing shows you the whole flow's state in one place, which is exactly the gap iteration 4 closes.
+
+<Card>
+**When would this design switch to orchestration instead?**
+
+The moment a step needs conditional branching that depends on more than the immediately preceding event — "if payment took longer than 30 seconds, cancel instead of waiting," "if this is a split shipment, wait for all parts before notifying" — that logic needs somewhere to live that can see the whole flow's state at once. That's exactly what an orchestrator is for. Don't retrofit that logic into a maze of choreographed listeners each guessing at global state from a local event; introduce an orchestrator (AWS Step Functions is a natural fit here, see the AWS mapping below) for that one flow, and let the rest of the system keep choreographing.
+</Card>
+
+With that settled, here's the failure iteration 1 has no plan for: payment already succeeds, and only afterward does inventory discover the item is out of stock.
+
+<Mermaid chart={`sequenceDiagram
+    participant O as Order Service
+    participant Bus as Event Bus
+    participant P as Payment Service
+    participant I as Inventory Service
+    participant N as Notification Service
+
+    O->>Bus: OrderPlaced
+    Bus->>P: OrderPlaced
+    P->>Bus: PaymentAuthorized
+    Bus->>I: PaymentAuthorized
+    I->>Bus: InventoryRejected (out of stock)
+    Bus->>P: InventoryRejected
+    P->>P: Compensate: refund the authorization
+    P->>Bus: PaymentRefunded
+    Bus->>N: InventoryRejected
+    N-->>O: "Sorry — item unavailable, refund issued"
+`} />
+
+Payment already succeeded by the time Inventory discovers the item is out of stock. There's no database transaction spanning both services to roll back — that's not available across service boundaries in this architecture, and pretending otherwise is how EDAs quietly turn into distributed monoliths. Instead, Payment Service subscribes to `InventoryRejected` specifically so it can run a **compensating action**: not undoing history (the charge really did happen), but publishing a new fact, `PaymentRefunded`, that corrects it going forward. This is the saga pattern's actual mechanism, and it's the reason every service in a choreographed saga needs to know not just what it produces, but what failure events elsewhere it needs to *react* to.
+
+<Callout icon="💡" type="informative">
+Design every event-producing step with its compensating action decided at the same time, not as an afterthought. "What happens if this step succeeds but a later one fails?" is a question with a concrete, nameable answer for every step here — `PaymentRefunded`, `InventoryReleased`, a cancellation notice — and if a step doesn't have one yet, the design isn't finished, even if the happy-path diagram looks complete.
+</Callout>
+
+## Iteration 3 — design for at-least-once delivery
+
+One issue named back in iteration 1 is still unaddressed: the bus this design relies on delivers *at-least once*, not *exactly once*. A consumer can process a message, crash before its acknowledgment commits, and receive the exact same message again when it restarts or a retry kicks in. Concretely: Payment Service reads `OrderPlaced`, successfully authorizes the charge with the payment provider, then crashes before it finishes publishing `PaymentAuthorized`. The bus, having never seen that publish succeed, redelivers `OrderPlaced`. Nothing in the design so far stops Payment Service from authorizing the same charge a second time.
+
+The fix has nothing to do with the bus and everything to do with how every consumer is written: every event carries an identifier, and every consumer checks, before acting, whether it's already processed that identifier. Payment Service records the event ID it authorized against; on redelivery, it recognizes the ID, confirms the charge already went through, and republishes `PaymentAuthorized` without charging anything twice.
+
+<Callout icon="💡" type="informative">
+Idempotency isn't a Payment-Service-specific fix — it's a property every consumer in this system needs. Inventory Service reserving the same stock twice, or Notification Service sending the same email twice, are the identical problem wearing a different service's name. "At-least-once" is a property of the bus, not of any one service on it, so the fix has to be a property of every consumer on it too.
+</Callout>
+
+## Iteration 4 — give choreography the observability it doesn't have for free
+
+Iterations 1 through 3 fix real problems, but they share a blind spot that's been there since choosing choreography in iteration 2: nothing in the design shows you the whole flow's state for one order, in one place. Each service knows its own slice; nothing knows the whole story.
+
+This iteration adds exactly one thing to close that gap: an append-only event store, keyed by order ID, that every event gets written to regardless of which service produced it.
 
 <Mermaid chart={`flowchart TD
     customer(["Customer"])
@@ -125,71 +228,21 @@ One level in, the single box becomes the actual services and the event bus routi
     shippingSvc -- "Books pickup" --> carrier
 `} />
 
-Every service is both a producer and a consumer, except Order Service (only produces, it's the entry point) and Notification Service (only consumes, it's the exit point). Nothing calls anything else's HTTP endpoint directly — every arrow that crosses a service boundary goes through the bus. That's the whole point made visible: no service holds a thread open waiting for another one.
+Every service is still both a producer and a consumer, except Order Service (only produces, it's the entry point) and Notification Service (only consumes, it's the exit point) — that hasn't changed since iteration 1. What's new is the dashed line into the Event Store: every event, from every iteration's addition, gets appended there too, so "what happened to order X, in order" has one place to look instead of being reconstructed by cross-referencing every service's own logs.
 
-## Following one order through the flow
+## Where this design would still need to change
 
-The container diagram shows *what can talk to what*; it doesn't show the order the events actually happen in for one specific order. That's what a sequence diagram is for — the happy path first:
+This is iteration 4's design, and it's the one the rest of this post assumes from here on — not because it's the end of every possible iteration, but because it's the end of the iterations this specific domain's shape actually requires. One further step is worth naming explicitly, because a reader's own domain might hit it sooner than this one did: the orchestration switch already named in iteration 2's aside above. Nothing here needed it, but plenty of real systems will.
 
-<Mermaid chart={`sequenceDiagram
-    participant C as Customer
-    participant O as Order Service
-    participant Bus as Event Bus
-    participant P as Payment Service
-    participant I as Inventory Service
-    participant S as Shipping Service
-    participant N as Notification Service
+## Mapping the final design onto AWS
 
-    C->>O: Place order
-    O->>Bus: OrderPlaced
-    Bus->>P: OrderPlaced
-    P->>Bus: PaymentAuthorized
-    Bus->>I: PaymentAuthorized
-    I->>Bus: InventoryReserved
-    Bus->>S: InventoryReserved
-    S->>Bus: OrderShipped
-    Bus->>N: OrderShipped
-    N-->>C: "Your order has shipped"
-`} />
-
-Notice what the customer's original request actually waits for: just `O->>Bus: OrderPlaced`. Everything after that happens outside the request/response cycle entirely. The customer gets an immediate "order accepted" response, and the rest of the diagram plays out over however long it actually takes — seconds, usually, but nothing breaks if the carrier takes an hour to confirm pickup.
-
-Now the path that actually justifies calling this a *design*, not just a happy-path diagram — what happens when a step fails after an earlier one already succeeded:
-
-<Mermaid chart={`sequenceDiagram
-    participant O as Order Service
-    participant Bus as Event Bus
-    participant P as Payment Service
-    participant I as Inventory Service
-    participant N as Notification Service
-
-    O->>Bus: OrderPlaced
-    Bus->>P: OrderPlaced
-    P->>Bus: PaymentAuthorized
-    Bus->>I: PaymentAuthorized
-    I->>Bus: InventoryRejected (out of stock)
-    Bus->>P: InventoryRejected
-    P->>P: Compensate: refund the authorization
-    P->>Bus: PaymentRefunded
-    Bus->>N: InventoryRejected
-    N-->>O: "Sorry — item unavailable, refund issued"
-`} />
-
-Payment already succeeded by the time Inventory discovers the item is out of stock. There's no database transaction spanning both services to roll back — that's not available across service boundaries in this architecture, and pretending otherwise is how EDAs quietly turn into distributed monoliths. Instead, Payment Service subscribes to `InventoryRejected` specifically so it can run a **compensating action**: not undoing history (the charge really did happen), but publishing a new fact, `PaymentRefunded`, that corrects it going forward. This is the saga pattern's actual mechanism, and it's the reason every service in a choreographed saga needs to know not just what it produces, but what failure events elsewhere it needs to *react* to.
-
-<Callout icon="💡" type="informative">
-Design every event-producing step with its compensating action decided at the same time, not as an afterthought. "What happens if this step succeeds but a later one fails?" is a question with a concrete, nameable answer for every step here — `PaymentRefunded`, `InventoryReleased`, a cancellation notice — and if a step doesn't have one yet, the design isn't finished, even if the happy-path diagram looks complete.
-</Callout>
-
-## Mapping the design onto AWS
-
-Nothing above names a specific vendor by accident until now — the container diagram already picked concrete AWS services, and here's the reasoning behind each choice, plus the alternatives that were considered and set aside for this scale:
+Iteration 4's design has been drawn in AWS-flavored terms all along — here's the reasoning behind each concrete choice, plus the alternatives that were considered and set aside for this scale:
 
 | Conceptual piece | AWS service | Why this one |
 |---|---|---|
 | Event bus | **Amazon EventBridge** | Built-in schema-based routing rules mean each service subscribes declaratively to the event *types* it cares about, with no consumer group or partition management to run yourself. Kafka on MSK is the better call once throughput or replay requirements grow past what EventBridge is built for — but that's a scaling decision to make later, not a starting assumption. |
 | Service compute | **AWS Lambda** | Each service here reacts to one event type and does bounded, short work — the textbook Lambda shape. Fargate becomes the better fit the moment a service needs to hold long-lived state in memory or run continuously regardless of event volume. |
-| Saga orchestration (for flows that need it) | **AWS Step Functions** | Named explicitly in the choreography-vs-orchestration callout above: the one place in this design where a flow needs to see its whole state at once, Step Functions gives that without hand-rolling a state machine. |
+| Saga orchestration (for flows that need it) | **AWS Step Functions** | Named explicitly in iteration 2's choreography-vs-orchestration aside: the one place in this design where a flow needs to see its whole state at once, Step Functions gives that without hand-rolling a state machine. |
 | Event store / audit log | **Amazon DynamoDB** | An append-only table keyed by order ID answers "what happened to this order, in order" — the one thing choreography's decentralization makes hard to see anywhere else. Cheap to write to, and TTL support lets old orders age out automatically if the business doesn't need indefinite retention. |
 | Dead-letter handling | **Amazon SQS (DLQ)** | EventBridge rules can target an SQS dead-letter queue directly when a consumer repeatedly fails to process an event, so a stuck message becomes a visible, alertable queue depth instead of a silently dropped event. |
 | Observability | **CloudWatch + AWS X-Ray** | X-Ray traces a correlation ID across every Lambda invocation the event triggers, reconstructing the sequence-diagram-shaped flow above from real production traffic — the closest thing choreography has to the orchestrator's built-in visibility. |
@@ -197,12 +250,12 @@ Nothing above names a specific vendor by accident until now — the container di
 <Card>
 **Why not just use Kafka from day one, since so much EDA literature is Kafka-first?**
 
-Ben Stopford's *Designing Event-Driven Systems* — written from inside Confluent, the company behind Kafka — makes a strong case for Kafka specifically when a system needs event *replay*, long retention, or very high throughput fan-out to many consumers. Nothing in this order-fulfillment design needs any of those yet: five services, one event per order per step, no requirement to replay six months of history to rebuild a read model. Reaching for Kafka (and the operational cost of running or managing it) before the design actually needs replay or throughput at that scale is optimizing for a problem this system doesn't have. EventBridge is the deliberately smaller starting point; migrating the event bus later doesn't touch the domain layer, per the business-layer section above.
+Ben Stopford's *Designing Event-Driven Systems* — written from inside Confluent, the company behind Kafka — makes a strong case for Kafka specifically when a system needs event *replay*, long retention, or very high throughput fan-out to many consumers. Nothing in this order-fulfillment design needs any of those yet: five services, one event per order per step, no requirement to replay six months of history to rebuild a read model. Reaching for Kafka (and the operational cost of running or managing it) before the design actually needs replay or throughput at that scale is optimizing for a problem this system doesn't have. EventBridge is the deliberately smaller starting point; migrating the event bus later doesn't touch the domain layer, per the standing rule above.
 </Card>
 
 ## The mental model to keep
 
-Diagrams describe this one system. The mental model below is what's meant to survive past this specific order-fulfillment example and apply to whatever event-driven system gets designed next:
+Four iterations describe this one system. The mental model below is what's meant to survive past this specific order-fulfillment example and apply to whatever event-driven system gets designed next:
 
 | If this happens... | Do this | Not this |
 |---|---|---|
@@ -214,15 +267,7 @@ Diagrams describe this one system. The mental model below is what's meant to sur
 | A flow needs a decision based on more than the immediately preceding event | Introduce an orchestrator for *that* flow | Chain conditional logic across choreographed listeners guessing at global state |
 | You're not sure whether two things are the "same" event or two different ones | Ask whether the business would describe them as one sentence or two | Merge them because it's fewer message types to define |
 
-## Why this way and not another — the actual design log
-
-Three decisions above deserve to be named explicitly as decisions, because a reader building their own system will face the same forks:
-
-- **Choreography over orchestration.** Chosen because no step here needs global flow state to make a local decision — see the choreography section above. This is a call specific to this domain's shape, not a universal preference; a flow with real branching logic would tip the other way, and that's fine — Step Functions is already in the toolbox for exactly that.
-- **EventBridge over Kafka.** Chosen for this scale and this lack of a replay requirement, per the AWS mapping section — not because Kafka is worse, but because it solves problems (replay, extreme fan-out, long retention) this design doesn't have yet.
-- **An explicit event store, even with choreography's decentralization.** Choreography's whole appeal is that no central piece needs to know about the whole flow — but that's also its cost: nothing shows you the whole flow's state in one place. The DynamoDB event store exists specifically to pay that cost back, on the observability side, without giving up the decoupling on the execution side.
-
-None of these are the *only* correct answers — they're the correct answers for a five-service order fulfillment flow with no complex branching, moderate throughput, and no replay requirement. Change any of those constraints and at least one of these three decisions should change with them. That's the actual skill this post is trying to hand off: not "here is the event-driven architecture," but the reasoning that produces one for whatever domain comes next.
+None of the four iterations above were the only correct next step — they're the correct next steps for a five-service order-fulfillment flow with no complex branching, moderate throughput, and no replay requirement. A different domain will hit its walls in a different order, or hit walls this one never did. That's the actual skill worth taking away: not "here is the event-driven architecture," but the habit of building the simplest thing that's honest about what it doesn't solve yet, and adding exactly the next iteration a real failure demands.
 
 ### Further Reading
 

--- a/content/event-driven-architecture-from-first-principles.mdx
+++ b/content/event-driven-architecture-from-first-principles.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Event-Driven Architecture: Designing an Order Fulfillment System from First Principles"
-description: The simplest event-driven design is never the finished one. This post builds an order fulfillment system iteration by iteration — each one fixing a concrete failure the last couldn't — from a synchronous handler to a production-ready, choreographed architecture.
+description: The simplest event-driven design is never the finished one. This post builds an order fulfillment system one design change at a time — each one fixing a concrete failure the last couldn't — from a synchronous handler to a production-ready, choreographed architecture.
 author: Igor Souza
 date: 2026-08-23
 published: true
@@ -9,11 +9,11 @@ tags: ["architecture", "event-driven", "aws", "distributed-systems", "system-des
 
 Picture the most obvious way to build an online store's checkout: a single `POST /orders` handler that, in one request, charges the customer's card, decrements inventory, books a carrier pickup, and sends a confirmation email — four synchronous calls, one after another, all inside the same HTTP request. It works in the demo. Then Black Friday traffic arrives, the carrier's API gets slow, and every request now holds its thread open waiting on a service you don't control and can't speed up. Threads pile up, the request queue backs up behind them, and soon customers whose payment already succeeded are staring at a spinner, because their order is stuck waiting on a shipping label. Worse: if the process crashes between "card charged" and "email sent," nothing remembers that charge ever happened. There's no record, no retry, no way back — just a customer who was billed for an order the system has no memory of.
 
-None of that is a bug in any one line of code. It's what happens when a business process that's inherently a sequence of independent steps, happening over time, gets modeled as one synchronous call stack. This post doesn't jump straight to the finished architecture — it builds toward it the way you'd actually have to: start from this synchronous baseline, add exactly the piece needed to fix whatever it breaks on next, and stop the moment the result actually holds up. Four iterations get from here to a production-ready, event-driven design, each one earning its complexity by fixing something the previous iteration genuinely couldn't. The domain is order fulfillment — Order Placed → Payment → Inventory → Shipping → Notification — chosen because it's the example nearly every serious treatment of EDA reaches for, from Gregor Hohpe's writing on enterprise integration to Adam Bellemare's *Building Event-Driven Microservices*. If you can reason about this one end to end, the reasoning transfers.
+None of that is a bug in any one line of code. It's what happens when a business process that's inherently a sequence of independent steps, happening over time, gets modeled as one synchronous call stack. This post doesn't jump straight to the finished architecture — it builds toward it the way you'd actually have to: start from this synchronous baseline, add exactly the piece needed to fix whatever it breaks on next, and stop the moment the result actually holds up. Four design changes get from here to a production-ready, event-driven design, each one earning its complexity by fixing something the previous step genuinely couldn't. The domain is order fulfillment — Order Placed → Payment → Inventory → Shipping → Notification — chosen because it's the example nearly every serious treatment of EDA reaches for, from Gregor Hohpe's writing on enterprise integration to Adam Bellemare's *Building Event-Driven Microservices*. If you can reason about this one end to end, the reasoning transfers.
 
-## Iteration 0 — name the baseline
+## Naming the baseline
 
-Before fixing the synchronous handler above, it's worth drawing it. The point of iteration 0 isn't to solve anything — just to be honest about what's actually there, so every later diagram can be judged against it:
+Before fixing the synchronous handler above, it's worth drawing it. The point isn't to solve anything yet — just to be honest about what's actually there, so every later diagram can be judged against it:
 
 <Mermaid chart={`flowchart LR
     customer(["Customer"])
@@ -32,15 +32,15 @@ The checkout handler above has a name for its core defect: **temporal coupling**
 
 Temporal coupling is what turns "the shipping carrier is having a slow day" into "the whole checkout system is down." Every synchronous dependency in the chain becomes a single point of failure for the entire chain, and the chain is only as fast as its slowest link. This is the actual problem event-driven architecture exists to solve: decouple *when* something happens from *when the thing that triggered it* happened, so a slow or failing step degrades gracefully instead of taking the whole flow down with it.
 
-## One rule that holds through every iteration below
+## One rule that holds through every design change below
 
-One thing gets decided now and never revisited by any iteration that follows: the business rules — what events exist, what order they happen in, what a valid order looks like — live in a domain layer that has never heard of AWS. That's the same discipline this blog covered in [Domain-Driven Design: Architecture That Grows with Your Business](/domain-driven-design-architecture-that-grows-with-your-business): domain events are domain objects, with zero imports from EventBridge's SDK, Kafka's client library, or any broker-specific serialization format; the domain decides *what* fact just became true, and only the infrastructure layer decides *how* that fact gets put on a bus.
+One thing gets decided now and never revisited by anything that follows: the business rules — what events exist, what order they happen in, what a valid order looks like — live in a domain layer that has never heard of AWS. That's the same discipline this blog covered in [Domain-Driven Design: Architecture That Grows with Your Business](/domain-driven-design-architecture-that-grows-with-your-business): domain events are domain objects, with zero imports from EventBridge's SDK, Kafka's client library, or any broker-specific serialization format; the domain decides *what* fact just became true, and only the infrastructure layer decides *how* that fact gets put on a bus.
 
-Every iteration below changes infrastructure — what publishes to what, what gets added to handle a new failure mode — and none of them should ever require touching what "a valid order" means. If migrating from choreography to an orchestrator, or from EventBridge to Kafka, means editing business logic, the boundary was drawn in the wrong place.
+Every change below is to infrastructure — what publishes to what, what gets added to handle a new failure mode — and none of them should ever require touching what "a valid order" means. If migrating from choreography to an orchestrator, or from EventBridge to Kafka, means editing business logic, the boundary was drawn in the wrong place.
 
 ## The outside view doesn't change
 
-Every iteration below changes what's happening *inside* the system. Nothing changes about what's happening at its edge — and that's worth drawing once, using the [C4 model](https://c4model.com), Simon Brown's now-standard notation for describing software architecture at different levels of zoom. This is the Context view: who talks to the system, from the outside, before any internal decision has been made yet:
+Every design change below changes what's happening *inside* the system. Nothing changes about what's happening at its edge — and that's worth drawing once, using the [C4 model](https://c4model.com), Simon Brown's now-standard notation for describing software architecture at different levels of zoom. This is the Context view: who talks to the system, from the outside, before any internal decision has been made yet:
 
 <Mermaid chart={`flowchart TD
     customer(["Customer\nPlaces an order in the online store"])
@@ -56,9 +56,9 @@ Every iteration below changes what's happening *inside* the system. Nothing chan
     notifyProvider -. "Delivers notification" .-> customer
 `} />
 
-Customer, payment provider, carrier, notification provider — none of that changes no matter which iteration below the system is currently on. Everything from here zooms into the *Container* view: what the system is actually made of, which is exactly what each iteration is about to change.
+Customer, payment provider, carrier, notification provider — none of that changes no matter which design the system's internals are currently running. Everything from here zooms into the *Container* view: what the system is actually made of, which is exactly what changes next.
 
-## Iteration 1 — decouple with events
+## Decouple with events
 
 The obvious fix for temporal coupling is: stop making synchronous calls, publish facts instead. Start from the business process, not the infrastructure — the order fulfillment flow is a sequence of *facts that became true*, and each one is a candidate event, named in the past tense because an event is something that already happened and can't be un-happened:
 
@@ -70,7 +70,7 @@ The obvious fix for temporal coupling is: stop making synchronous calls, publish
 
 Each event carries only what the *next* step needs to act — an order ID, the fields relevant to that step, and a correlation identifier tying every event for one order back together — not a dump of the entire order object. That restraint matters: an event with too much data becomes a second API contract nobody agreed to, and every field a consumer starts relying on is a field the producer can no longer change without breaking someone downstream.
 
-Wire those events through a bus and this iteration's design already looks nothing like iteration 0's straight line:
+Wire those events through a bus and this design already looks nothing like the synchronous baseline's straight line:
 
 <Mermaid chart={`flowchart TD
     customer(["Customer"])
@@ -98,7 +98,7 @@ Wire those events through a bus and this iteration's design already looks nothin
     shippingSvc -- "Books pickup" --> carrier
 `} />
 
-This already fixes iteration 0's Black Friday problem. Notice what the customer's original request now waits for: just publishing `OrderPlaced`. Everything after that happens outside the request/response cycle entirely, on whatever service reacts to it. Here's one order flowing through this design, happy path:
+This already fixes the synchronous baseline's Black Friday problem. Notice what the customer's original request now waits for: just publishing `OrderPlaced`. Everything after that happens outside the request/response cycle entirely, on whatever service reacts to it. Here's one order flowing through this design, happy path:
 
 <Mermaid chart={`sequenceDiagram
     participant C as Customer
@@ -121,26 +121,26 @@ This already fixes iteration 0's Black Friday problem. Notice what the customer'
     N-->>C: "Your order has shipped"
 `} />
 
-The customer gets an immediate "order accepted" response, and the rest plays out over however long it actually takes — nothing breaks if the carrier takes an hour to confirm pickup, the way it would have in iteration 0.
+The customer gets an immediate "order accepted" response, and the rest plays out over however long it actually takes — nothing breaks if the carrier takes an hour to confirm pickup, the way it would have in the synchronous baseline.
 
-### What iteration 1 doesn't solve yet
+### What decoupling with events doesn't solve yet
 
 The instinct here is to declare victory — decoupled, no more thread starvation, done. That's exactly the trap Gregor Hohpe, co-author of *Enterprise Integration Patterns*, has written about directly. Event-driven systems, he notes, "tend to exhibit an aura of simple elegance," and because they're "modeled after real world events the resulting system model is usually very expressive." That's true, and it's also the danger: "the simple elegance of EDAs can be deceiving," because designing one correctly is often *more* work than the synchronous version it replaces, not less.
 
-Four issues are already sitting inside iteration 1, waiting to show up in production:
+Four issues are already sitting inside this design, waiting to show up in production:
 
-- **Coupling didn't disappear, it moved.** Two services no longer call each other directly, but if a consumer depends on the exact shape of a producer's event, they're still coupled — just through a schema instead of a function signature. Hohpe's point above is precisely this: "loosely coupled" is a design goal EDA makes *possible*, not one it grants automatically. No iteration below removes this — it's a standing tradeoff every event schema change has to respect, not a bug to patch out.
-- **Consistency becomes eventual, not immediate.** The moment `OrderPlaced` is published, the order exists in "placed" state everywhere except the services that haven't processed that event yet. No iteration below removes this either — it's accepted, and the escape hatch (a dedicated, strongly consistent read model, i.e. CQRS) shows up in the mental model at the end, not as a design iteration of its own.
-- **Ordering and duplication aren't guaranteed for free.** Most brokers deliver *at-least once* — meaning the same event can arrive twice. A consumer that isn't built to handle a duplicate `PaymentAuthorized` will, sooner or later, double-charge something. **Iteration 3 exists specifically to fix this.**
-- **A failure has nowhere obvious to go.** In a synchronous call, a failure is a stack trace with a caller waiting for it. In an event-driven flow, unless something explicitly decides what happens next, a failure just evaporates. **Iteration 2 exists specifically to fix this.**
+- **Coupling didn't disappear, it moved.** Two services no longer call each other directly, but if a consumer depends on the exact shape of a producer's event, they're still coupled — just through a schema instead of a function signature. Hohpe's point above is precisely this: "loosely coupled" is a design goal EDA makes *possible*, not one it grants automatically. Nothing below removes this — it's a standing tradeoff every event schema change has to respect, not a bug to patch out.
+- **Consistency becomes eventual, not immediate.** The moment `OrderPlaced` is published, the order exists in "placed" state everywhere except the services that haven't processed that event yet. Nothing below removes this either — it's accepted, and the escape hatch (a dedicated, strongly consistent read model, i.e. CQRS) shows up in the mental model at the end, not as a design change of its own.
+- **Ordering and duplication aren't guaranteed for free.** Most brokers deliver *at-least once* — meaning the same event can arrive twice. A consumer that isn't built to handle a duplicate `PaymentAuthorized` will, sooner or later, double-charge something. **Designing for at-least-once delivery, below, exists specifically to fix this.**
+- **A failure has nowhere obvious to go.** In a synchronous call, a failure is a stack trace with a caller waiting for it. In an event-driven flow, unless something explicitly decides what happens next, a failure just evaporates. **Compensating actions, below, exist specifically to fix this.**
 
 <Callout icon="⚠️" type="warning">
-Two of these four are permanent tradeoffs, not defects — no amount of further iteration removes coupling-through-schema or eventual consistency, it only manages them. Confusing "iterate until every EDA property disappears" with "iterate until the properties that are actually fixable are fixed, and treat the rest as deliberate" is how designs either stall forever chasing an impossible target, or ship pretending they addressed tradeoffs they never actually did.
+Two of these four are permanent tradeoffs, not defects — no amount of further design work removes coupling-through-schema or eventual consistency, it only manages them. Confusing "keep changing the design until every EDA property disappears" with "keep changing it until the properties that are actually fixable are fixed, and treat the rest as deliberate" is how designs either stall forever chasing an impossible target, or ship pretending they addressed tradeoffs they never actually did.
 </Callout>
 
-## Iteration 2 — handle partial failure with compensating actions
+## Handle partial failure with compensating actions
 
-Something has to decide what triggers what, and — separately — what happens when a step downstream fails after an upstream step already succeeded. Both questions get answered by this iteration.
+Something has to decide what triggers what, and — separately — what happens when a step downstream fails after an upstream step already succeeded. Both questions get answered here.
 
 ### Choreography or orchestration — and why this design picks one
 
@@ -149,7 +149,7 @@ There are two well-established shapes for deciding what triggers what, both name
 - **Choreography**: every service reacts to events on its own. Payment Service listens for `OrderPlaced`; Inventory Service listens for `PaymentAuthorized`; nothing sits in the middle telling anyone what to do next. The flow *emerges* from each service's own subscriptions.
 - **Orchestration**: a central coordinator (Richardson calls it a saga orchestrator) explicitly calls each service in turn and tracks the state of the whole flow itself.
 
-For this system, **choreography is the right call**, for a specific reason: the order fulfillment flow has no step that needs to make a decision based on the *whole* flow's state — each service only ever needs to know about the one event immediately before it. There's no branching logic like "if the customer is a VIP, skip inventory reservation and orchestrate a rush order" that would need a central brain watching everything at once. Adam Bellemare's *Building Event-Driven Microservices* makes the same call for this class of problem: choreography keeps each service's logic local and lets services be added or removed from the flow without touching a central coordinator's code. The tradeoff, and it's real, is observability — nothing shows you the whole flow's state in one place, which is exactly the gap iteration 4 closes.
+For this system, **choreography is the right call**, for a specific reason: the order fulfillment flow has no step that needs to make a decision based on the *whole* flow's state — each service only ever needs to know about the one event immediately before it. There's no branching logic like "if the customer is a VIP, skip inventory reservation and orchestrate a rush order" that would need a central brain watching everything at once. Adam Bellemare's *Building Event-Driven Microservices* makes the same call for this class of problem: choreography keeps each service's logic local and lets services be added or removed from the flow without touching a central coordinator's code. The tradeoff, and it's real, is observability — nothing shows you the whole flow's state in one place, which is exactly the gap the event store, below, closes.
 
 <Card>
 **When would this design switch to orchestration instead?**
@@ -157,7 +157,7 @@ For this system, **choreography is the right call**, for a specific reason: the 
 The moment a step needs conditional branching that depends on more than the immediately preceding event — "if payment took longer than 30 seconds, cancel instead of waiting," "if this is a split shipment, wait for all parts before notifying" — that logic needs somewhere to live that can see the whole flow's state at once. That's exactly what an orchestrator is for. Don't retrofit that logic into a maze of choreographed listeners each guessing at global state from a local event; introduce an orchestrator (AWS Step Functions is a natural fit here, see the AWS mapping below) for that one flow, and let the rest of the system keep choreographing.
 </Card>
 
-With that settled, here's the failure iteration 1 has no plan for: payment already succeeds, and only afterward does inventory discover the item is out of stock.
+With that settled, here's the failure decoupling with events has no plan for: payment already succeeds, and only afterward does inventory discover the item is out of stock.
 
 <Mermaid chart={`sequenceDiagram
     participant O as Order Service
@@ -184,9 +184,9 @@ Payment already succeeded by the time Inventory discovers the item is out of sto
 Design every event-producing step with its compensating action decided at the same time, not as an afterthought. "What happens if this step succeeds but a later one fails?" is a question with a concrete, nameable answer for every step here — `PaymentRefunded`, `InventoryReleased`, a cancellation notice — and if a step doesn't have one yet, the design isn't finished, even if the happy-path diagram looks complete.
 </Callout>
 
-## Iteration 3 — design for at-least-once delivery
+## Design for at-least-once delivery
 
-One issue named back in iteration 1 is still unaddressed: the bus this design relies on delivers *at-least once*, not *exactly once*. A consumer can process a message, crash before its acknowledgment commits, and receive the exact same message again when it restarts or a retry kicks in. Concretely: Payment Service reads `OrderPlaced`, successfully authorizes the charge with the payment provider, then crashes before it finishes publishing `PaymentAuthorized`. The bus, having never seen that publish succeed, redelivers `OrderPlaced`. Nothing in the design so far stops Payment Service from authorizing the same charge a second time.
+One issue named back in decoupling with events is still unaddressed: the bus this design relies on delivers *at-least once*, not *exactly once*. A consumer can process a message, crash before its acknowledgment commits, and receive the exact same message again when it restarts or a retry kicks in. Concretely: Payment Service reads `OrderPlaced`, successfully authorizes the charge with the payment provider, then crashes before it finishes publishing `PaymentAuthorized`. The bus, having never seen that publish succeed, redelivers `OrderPlaced`. Nothing in the design so far stops Payment Service from authorizing the same charge a second time.
 
 The fix has nothing to do with the bus and everything to do with how every consumer is written: every event carries an identifier, and every consumer checks, before acting, whether it's already processed that identifier. Payment Service records the event ID it authorized against; on redelivery, it recognizes the ID, confirms the charge already went through, and republishes `PaymentAuthorized` without charging anything twice.
 
@@ -194,11 +194,11 @@ The fix has nothing to do with the bus and everything to do with how every consu
 Idempotency isn't a Payment-Service-specific fix — it's a property every consumer in this system needs. Inventory Service reserving the same stock twice, or Notification Service sending the same email twice, are the identical problem wearing a different service's name. "At-least-once" is a property of the bus, not of any one service on it, so the fix has to be a property of every consumer on it too.
 </Callout>
 
-## Iteration 4 — give choreography the observability it doesn't have for free
+## Give choreography the observability it doesn't have for free
 
-Iterations 1 through 3 fix real problems, but they share a blind spot that's been there since choosing choreography in iteration 2: nothing in the design shows you the whole flow's state for one order, in one place. Each service knows its own slice; nothing knows the whole story.
+Decoupling with events, compensating actions, and idempotent delivery all fix real problems, but they share a blind spot that's been there since choosing choreography: nothing in the design shows you the whole flow's state for one order, in one place. Each service knows its own slice; nothing knows the whole story.
 
-This iteration adds exactly one thing to close that gap: an append-only event store, keyed by order ID, that every event gets written to regardless of which service produced it.
+This adds exactly one thing to close that gap: an append-only event store, keyed by order ID, that every event gets written to regardless of which service produced it.
 
 <Mermaid chart={`flowchart TD
     customer(["Customer"])
@@ -228,24 +228,53 @@ This iteration adds exactly one thing to close that gap: an append-only event st
     shippingSvc -- "Books pickup" --> carrier
 `} />
 
-Every service is still both a producer and a consumer, except Order Service (only produces, it's the entry point) and Notification Service (only consumes, it's the exit point) — that hasn't changed since iteration 1. What's new is the dashed line into the Event Store: every event, from every iteration's addition, gets appended there too, so "what happened to order X, in order" has one place to look instead of being reconstructed by cross-referencing every service's own logs.
+Every service is still both a producer and a consumer, except Order Service (only produces, it's the entry point) and Notification Service (only consumes, it's the exit point) — that hasn't changed since decoupling with events. What's new is the dashed line into the Event Store: every event, from every design change above, gets appended there too, so "what happened to order X, in order" has one place to look instead of being reconstructed by cross-referencing every service's own logs.
 
 ## Where this design would still need to change
 
-This is iteration 4's design, and it's the one the rest of this post assumes from here on — not because it's the end of every possible iteration, but because it's the end of the iterations this specific domain's shape actually requires. One further step is worth naming explicitly, because a reader's own domain might hit it sooner than this one did: the orchestration switch already named in iteration 2's aside above. Nothing here needed it, but plenty of real systems will.
+This is the design the rest of this post assumes from here on — not because it's the end of every possible design change, but because it's the end of the changes this specific domain's shape actually requires. One further step is worth naming explicitly, because a reader's own domain might hit it sooner than this one did: the orchestration switch already named in the compensating-actions aside above. Nothing here needed it, but plenty of real systems will.
 
 ## Mapping the final design onto AWS
 
-Iteration 4's design has been drawn in AWS-flavored terms all along — here's the reasoning behind each concrete choice, plus the alternatives that were considered and set aside for this scale:
+This design has been drawn in AWS-flavored terms all along — here's the reasoning behind each concrete choice, plus the alternatives that were considered and set aside for this scale:
 
 | Conceptual piece | AWS service | Why this one |
 |---|---|---|
 | Event bus | **Amazon EventBridge** | Built-in schema-based routing rules mean each service subscribes declaratively to the event *types* it cares about, with no consumer group or partition management to run yourself. Kafka on MSK is the better call once throughput or replay requirements grow past what EventBridge is built for — but that's a scaling decision to make later, not a starting assumption. |
 | Service compute | **AWS Lambda** | Each service here reacts to one event type and does bounded, short work — the textbook Lambda shape. Fargate becomes the better fit the moment a service needs to hold long-lived state in memory or run continuously regardless of event volume. |
-| Saga orchestration (for flows that need it) | **AWS Step Functions** | Named explicitly in iteration 2's choreography-vs-orchestration aside: the one place in this design where a flow needs to see its whole state at once, Step Functions gives that without hand-rolling a state machine. |
+| Saga orchestration (for flows that need it) | **AWS Step Functions** | Named explicitly in the choreography-vs-orchestration aside above: the one place in this design where a flow needs to see its whole state at once, Step Functions gives that without hand-rolling a state machine. |
 | Event store / audit log | **Amazon DynamoDB** | An append-only table keyed by order ID answers "what happened to this order, in order" — the one thing choreography's decentralization makes hard to see anywhere else. Cheap to write to, and TTL support lets old orders age out automatically if the business doesn't need indefinite retention. |
 | Dead-letter handling | **Amazon SQS (DLQ)** | EventBridge rules can target an SQS dead-letter queue directly when a consumer repeatedly fails to process an event, so a stuck message becomes a visible, alertable queue depth instead of a silently dropped event. |
 | Observability | **CloudWatch + AWS X-Ray** | X-Ray traces a correlation ID across every Lambda invocation the event triggers, reconstructing the sequence-diagram-shaped flow above from real production traffic — the closest thing choreography has to the orchestrator's built-in visibility. |
+
+Same table, drawn as an actual AWS deployment instead of a list:
+
+<Mermaid chart={`architecture-beta
+    group vpc(cloud)[Order Fulfillment System]
+
+    service gw(logos:aws-api-gateway)[API Gateway] in vpc
+    service bus(logos:aws-eventbridge)[Event Bus] in vpc
+    service orderSvc(logos:aws-lambda)[Order Service] in vpc
+    service paymentSvc(logos:aws-lambda)[Payment Service] in vpc
+    service inventorySvc(logos:aws-lambda)[Inventory Service] in vpc
+    service shippingSvc(logos:aws-lambda)[Shipping Service] in vpc
+    service notifySvc(logos:aws-lambda)[Notification Service] in vpc
+    service store(logos:aws-dynamodb)[Event Store] in vpc
+    service dlq(logos:aws-sqs)[Dead-letter Queue] in vpc
+    service saga(logos:aws-step-functions)[Step Functions] in vpc
+    service obs(logos:aws-cloudwatch)[CloudWatch / X-Ray] in vpc
+
+    gw:R -- L:orderSvc
+    orderSvc:R -- L:bus
+    bus:T -- B:paymentSvc
+    bus:R -- L:inventorySvc
+    bus:B -- T:shippingSvc
+    paymentSvc:T -- B:saga
+    paymentSvc:L -- R:dlq
+    dlq:T -- B:store
+    inventorySvc:T -- B:obs
+    shippingSvc:R -- L:notifySvc
+`} />
 
 <Card>
 **Why not just use Kafka from day one, since so much EDA literature is Kafka-first?**
@@ -255,7 +284,7 @@ Ben Stopford's *Designing Event-Driven Systems* — written from inside Confluen
 
 ## The mental model to keep
 
-Four iterations describe this one system. The mental model below is what's meant to survive past this specific order-fulfillment example and apply to whatever event-driven system gets designed next:
+Four design changes describe this one system. The mental model below is what's meant to survive past this specific order-fulfillment example and apply to whatever event-driven system gets designed next:
 
 | If this happens... | Do this | Not this |
 |---|---|---|
@@ -267,7 +296,7 @@ Four iterations describe this one system. The mental model below is what's meant
 | A flow needs a decision based on more than the immediately preceding event | Introduce an orchestrator for *that* flow | Chain conditional logic across choreographed listeners guessing at global state |
 | You're not sure whether two things are the "same" event or two different ones | Ask whether the business would describe them as one sentence or two | Merge them because it's fewer message types to define |
 
-None of the four iterations above were the only correct next step — they're the correct next steps for a five-service order-fulfillment flow with no complex branching, moderate throughput, and no replay requirement. A different domain will hit its walls in a different order, or hit walls this one never did. That's the actual skill worth taking away: not "here is the event-driven architecture," but the habit of building the simplest thing that's honest about what it doesn't solve yet, and adding exactly the next iteration a real failure demands.
+None of the four changes above were the only correct next step — they're the correct next steps for a five-service order-fulfillment flow with no complex branching, moderate throughput, and no replay requirement. A different domain will hit its walls in a different order, or hit walls this one never did. That's the actual skill worth taking away: not "here is the event-driven architecture," but the habit of building the simplest thing that's honest about what it doesn't solve yet, and adding exactly the next piece a real failure demands.
 
 ### Further Reading
 

--- a/content/event-driven-architecture-from-first-principles.mdx
+++ b/content/event-driven-architecture-from-first-principles.mdx
@@ -249,31 +249,39 @@ This design has been drawn in AWS-flavored terms all along — here's the reason
 
 Same table, drawn as an actual AWS deployment instead of a list:
 
-<Mermaid chart={`architecture-beta
-    group vpc(cloud)[Order Fulfillment System]
+<Mermaid chart={`flowchart TD
+    customer(["Customer"])
+    paymentProvider[["Payment Provider"]]
+    carrier[["Shipping Carrier"]]
 
-    service gw(logos:aws-api-gateway)[API Gateway] in vpc
-    service bus(logos:aws-eventbridge)[Event Bus] in vpc
-    service orderSvc(logos:aws-lambda)[Order Service] in vpc
-    service paymentSvc(logos:aws-lambda)[Payment Service] in vpc
-    service inventorySvc(logos:aws-lambda)[Inventory Service] in vpc
-    service shippingSvc(logos:aws-lambda)[Shipping Service] in vpc
-    service notifySvc(logos:aws-lambda)[Notification Service] in vpc
-    service store(logos:aws-dynamodb)[Event Store] in vpc
-    service dlq(logos:aws-sqs)[Dead-letter Queue] in vpc
-    service saga(logos:aws-step-functions)[Step Functions] in vpc
-    service obs(logos:aws-cloudwatch)[CloudWatch / X-Ray] in vpc
+    subgraph aws["AWS Account"]
+        direction TB
+        orderSvc["Order Service\nLambda"]
+        bus{{"Event Bus\nEventBridge"}}
+        paymentSvc["Payment Service\nLambda"]
+        inventorySvc["Inventory Service\nLambda"]
+        shippingSvc["Shipping Service\nLambda"]
+        notifySvc["Notification Service\nLambda"]
+        store[("Event Store\nDynamoDB")]
+        dlq[/"Dead-letter Queue\nSQS"/]
+        saga(["Step Functions"])
+        obs["CloudWatch / X-Ray"]
 
-    gw:R -- L:orderSvc
-    orderSvc:R -- L:bus
-    bus:T -- B:paymentSvc
-    bus:R -- L:inventorySvc
-    bus:B -- T:shippingSvc
-    paymentSvc:T -- B:saga
-    paymentSvc:L -- R:dlq
-    dlq:T -- B:store
-    inventorySvc:T -- B:obs
-    shippingSvc:R -- L:notifySvc
+        orderSvc -- "OrderPlaced" --> bus
+        bus <-- "PaymentAuthorized /\nPaymentFailed" --> paymentSvc
+        bus <-- "InventoryReserved /\nInventoryRejected" --> inventorySvc
+        bus <-- "OrderShipped" --> shippingSvc
+        bus -- "every order event" --> notifySvc
+        bus -. "every event, appended" .-> store
+        orderSvc -. "failed deliveries" .-> dlq
+        paymentSvc -. "long-running saga" .-> saga
+        inventorySvc -. "traces" .-> obs
+    end
+
+    customer -- "POST /orders" --> orderSvc
+    paymentSvc -- "Authorizes charge" --> paymentProvider
+    shippingSvc -- "Books pickup" --> carrier
+    paymentProvider ~~~ carrier
 `} />
 
 <Card>

--- a/e2e/mermaid.spec.ts
+++ b/e2e/mermaid.spec.ts
@@ -10,9 +10,12 @@ test.describe("Mermaid diagrams", () => {
   }) => {
     await page.goto(POST_URL);
 
-    const diagrams = page.locator("[data-mermaid] svg");
+    // Direct child only — the AWS architecture diagram embeds per-icon
+    // <svg> elements nested inside its own diagram <svg>, which a
+    // descendant selector would also count.
+    const diagrams = page.locator("[data-mermaid] > svg");
     await expect(diagrams.first()).toBeVisible({ timeout: 10_000 });
-    await expect(diagrams).toHaveCount(6);
+    await expect(diagrams).toHaveCount(7);
 
     // The raw Mermaid syntax should never be visible as text — it should
     // have been replaced by the rendered SVG.

--- a/e2e/mermaid.spec.ts
+++ b/e2e/mermaid.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "@playwright/test";
+import { routeAudio } from "./fixtures/tts";
+
+const POST_URL = "event-driven-architecture-from-first-principles";
+const SLUG = "event-driven-architecture-from-first-principles";
+
+test.describe("Mermaid diagrams", () => {
+  test("C4 and sequence diagrams render as SVG, not raw text", async ({
+    page,
+  }) => {
+    await page.goto(POST_URL);
+
+    const diagrams = page.locator("[data-mermaid] svg");
+    await expect(diagrams.first()).toBeVisible({ timeout: 10_000 });
+    await expect(diagrams).toHaveCount(4);
+
+    // The raw Mermaid syntax should never be visible as text — it should
+    // have been replaced by the rendered SVG.
+    await expect(page.getByText("C4Context", { exact: false })).toHaveCount(
+      0
+    );
+  });
+
+  test("diagram content is excluded from read-aloud word-wrapping", async ({
+    page,
+  }) => {
+    await routeAudio(page, { slug: SLUG });
+    await page.goto(POST_URL);
+
+    await page
+      .getByRole("button", { name: /listen to this article/i })
+      .click();
+    const dialog = page.getByRole("dialog", { name: /audio player/i });
+    await dialog.getByRole("button", { name: "Play", exact: true }).click();
+
+    // wrapWords() runs once playback starts and wraps every narratable DOM
+    // token in a span[data-tts-word] — diagram labels inside [data-mermaid]
+    // must never be among them (see lib/tts-text.ts SKIP_SELECTOR).
+    await expect(
+      page.locator("#article-body span[data-tts-word]").first()
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.locator("[data-mermaid] span[data-tts-word]")
+    ).toHaveCount(0);
+  });
+});

--- a/e2e/mermaid.spec.ts
+++ b/e2e/mermaid.spec.ts
@@ -5,14 +5,14 @@ const POST_URL = "event-driven-architecture-from-first-principles";
 const SLUG = "event-driven-architecture-from-first-principles";
 
 test.describe("Mermaid diagrams", () => {
-  test("C4 and sequence diagrams render as SVG, not raw text", async ({
+  test("all iteration diagrams render as SVG, not raw text", async ({
     page,
   }) => {
     await page.goto(POST_URL);
 
     const diagrams = page.locator("[data-mermaid] svg");
     await expect(diagrams.first()).toBeVisible({ timeout: 10_000 });
-    await expect(diagrams).toHaveCount(4);
+    await expect(diagrams).toHaveCount(6);
 
     // The raw Mermaid syntax should never be visible as text — it should
     // have been replaced by the rendered SVG.

--- a/e2e/post-navigation.spec.ts
+++ b/e2e/post-navigation.spec.ts
@@ -6,7 +6,7 @@ import { test, expect } from "@playwright/test";
 // suite.
 const OLDEST_POST = "welcome";
 const MIDDLE_POST = "we-need-to-talk-about-gil";
-const NEWEST_POST = "kafka-consumers-fastapi-and-the-kubernetes-amnesia-problem";
+const NEWEST_POST = "event-driven-architecture-from-first-principles";
 
 test.describe("Post navigation", () => {
   test("middle post shows both previous and next links", async ({ page }) => {

--- a/lib/tts-text.ts
+++ b/lib/tts-text.ts
@@ -8,8 +8,13 @@
 
 export const NARRATION_ROOT_ID = "article-body";
 
+// [data-mermaid]: Mermaid diagrams render to an inline SVG client-side,
+// after hydration. Their <text>/<tspan> labels are visual diagram content,
+// not narration, and wrapping them in HTML <span>s (as wrapWords below
+// does for narratable text) is invalid inside SVG and can break the
+// diagram's rendering — so they're excluded the same way <pre>/<table> are.
 export const SKIP_SELECTOR =
-  "pre, table, figure[data-rehype-pretty-code-figure]";
+  "pre, table, figure[data-rehype-pretty-code-figure], [data-mermaid]";
 
 const BLOCK_TAGS = new Set([
   "P",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "lucide-react": "^0.364.0",
+        "mermaid": "^11.4.1",
         "next": "14.2.35",
         "react": "^18",
         "react-dom": "^18",
@@ -63,6 +64,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -219,6 +233,18 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -1033,6 +1059,23 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "dev": true
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.33.3",
       "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.3.tgz",
@@ -1612,6 +1655,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.1.tgz",
+      "integrity": "sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.2"
+      }
+    },
     "node_modules/@mui/base": {
       "version": "5.0.0-beta.40",
       "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.40.tgz",
@@ -1922,9 +1974,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1940,9 +1989,6 @@
       "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1960,9 +2006,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1978,9 +2021,6 @@
       "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2206,6 +2246,259 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
+      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-kVd74ta9eof3eJOvbNd1vGKS/XERRyQbT26Og63hIsvDO84cjD5gEOhsXf26w3FSoNlPVz84DOFcKv/oou+fMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2229,6 +2522,12 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -2329,6 +2628,13 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.2",
@@ -2623,6 +2929,16 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/acorn": {
       "version": "8.11.3",
@@ -3382,6 +3698,15 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -3455,6 +3780,514 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
+    "node_modules/cytoscape": {
+      "version": "3.34.1",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.1.tgz",
+      "integrity": "sha512-Lr0RvH9H75y9ar8h9Toy6u4lxRSCcxUq+hHcQ26sVWo6BnaQp1gwEZOYqwuYTZhyW7npyKnNLP8oJ2p1/3OZ7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -3525,6 +4358,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.23",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+      "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3604,6 +4443,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3674,6 +4522,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -3903,6 +4760,18 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.51.0.tgz",
+      "integrity": "sha512-zC2lQGkM7QX+Gm6iM3+WIdZJzthsEd14LvRNJneSO2hzyz/zNBENR8+YXWo1cKxgPBtV6ksPYHELbcwBRzmdCw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types",
+        "tests/browser-compat"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.20.2",
@@ -4503,6 +5372,15 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fastdom": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastdom/-/fastdom-1.0.12.tgz",
+      "integrity": "sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==",
+      "license": "MIT",
+      "dependencies": {
+        "strictdom": "^1.0.1"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -4865,6 +5743,12 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -5190,7 +6074,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -5221,6 +6104,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/imurmurhash": {
@@ -5266,6 +6159,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-alphabetical": {
@@ -5864,6 +6766,31 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5872,6 +6799,11 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.22",
@@ -5890,6 +6822,12 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -5931,6 +6869,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
     },
     "node_modules/lodash.castarray": {
       "version": "4.4.0",
@@ -6005,6 +6949,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -6323,6 +7279,42 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/mermaid": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.17.0.tgz",
+      "integrity": "sha512-Jo9N377Wb4MSnHFPTbLi2SxFpsQl4eVHoxnW5U1Md9EazvgMp3s+4ohDxr81YNTgbn5Kj7HJ3yslrSJ52kwpbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.2",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.2.1",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.34.0",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.21",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "fastdom": "1.0.12",
+        "katex": "^0.16.47",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
     },
     "node_modules/micromark": {
       "version": "4.0.0",
@@ -7440,6 +8432,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7511,6 +8509,12 @@
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -7645,6 +8649,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7653,6 +8658,22 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -8227,6 +9248,24 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
@@ -8255,6 +9294,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.2",
@@ -8295,7 +9340,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -8524,6 +9568,12 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/strictdom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strictdom/-/strictdom-1.0.1.tgz",
+      "integrity": "sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -8919,6 +9969,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -9046,6 +10105,15 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -9831,6 +10899,19 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
+      "integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/velite": {
       "version": "0.1.0-beta.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
-        "@iconify-json/logos": "^1.2.13",
         "@mui/icons-material": "^5.15.14",
         "@mui/material": "^5.15.14",
         "@radix-ui/react-slot": "^1.0.2",
@@ -1059,15 +1058,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "dev": true
-    },
-    "node_modules/@iconify-json/logos": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/@iconify-json/logos/-/logos-1.2.13.tgz",
-      "integrity": "sha512-Up54ZnIuiuBgGAsuzhR1nvKqwq8VE6YM3XLwVB6IgY+7NAasz6WKu9Ay5hGfAkfuOKowodfwDC8ozReEBYrWRg==",
-      "license": "CC0-1.0",
-      "dependencies": {
-        "@iconify/types": "*"
-      }
     },
     "node_modules/@iconify/types": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
+        "@iconify-json/logos": "^1.2.13",
         "@mui/icons-material": "^5.15.14",
         "@mui/material": "^5.15.14",
         "@radix-ui/react-slot": "^1.0.2",
@@ -1058,6 +1059,15 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "dev": true
+    },
+    "node_modules/@iconify-json/logos": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/@iconify-json/logos/-/logos-1.2.13.tgz",
+      "integrity": "sha512-Up54ZnIuiuBgGAsuzhR1nvKqwq8VE6YM3XLwVB6IgY+7NAasz6WKu9Ay5hGfAkfuOKowodfwDC8ozReEBYrWRg==",
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
     },
     "node_modules/@iconify/types": {
       "version": "2.0.0",
@@ -8649,7 +8659,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
+    "@iconify-json/logos": "^1.2.13",
     "@mui/icons-material": "^5.15.14",
     "@mui/material": "^5.15.14",
     "@radix-ui/react-slot": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
-    "@iconify-json/logos": "^1.2.13",
     "@mui/icons-material": "^5.15.14",
     "@mui/material": "^5.15.14",
     "@radix-ui/react-slot": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "lucide-react": "^0.364.0",
+    "mermaid": "^11.4.1",
     "next": "14.2.35",
     "react": "^18",
     "react-dom": "^18",


### PR DESCRIPTION
New post walks through designing an event-driven order fulfillment
system from first principles: the failure modes of a synchronous
checkout, the principal issues EDA itself introduces (Hohpe), building
the event model piece by piece with a choreography-vs-orchestration
decision, keeping the domain layer independent of infrastructure, an
AWS service mapping, and a reusable decision mental model.

Adds live Mermaid rendering (new dependency + components/mermaid.tsx,
client-only via next/dynamic) since the blog had none, using Mermaid's
C4 diagram syntax for the full-view/zoomed-in requirement. Extends
lib/tts-text.ts's SKIP_SELECTOR to exclude Mermaid's rendered SVG from
the read-aloud word-highlighter, since wrapWords() runs against the
live post-hydration DOM and would otherwise wrap diagram labels in
invalid HTML spans inside SVG text nodes.

Also fixes e2e/post-navigation.spec.ts's hard-coded NEWEST_POST, which
this new post (as the latest by date) supersedes.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0189tBXCx3VsffsvX17jockb